### PR TITLE
OSW-575: Add FastAPI dependency for retrieving auth token from requests headers.

### DIFF
--- a/doc/news/OSW-575.feature.rst
+++ b/doc/news/OSW-575.feature.rst
@@ -1,0 +1,1 @@
+Add FastAPI dependency for retrieving auth token from requests headers.

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -471,6 +471,7 @@ class NightReportAdapter(SourceAdapter):
         limit=None,
         verbose=False,
         warning=False,
+        auth_token=None,
     ):
         super().__init__(
             server_url=server_url,
@@ -479,6 +480,7 @@ class NightReportAdapter(SourceAdapter):
             limit=limit,
             verbose=verbose,
             warning=warning,
+            auth_token=auth_token,
         )
 
         # status[endpoint] = dict(endpoint_url, number_of_records, error)
@@ -940,6 +942,7 @@ class ExposurelogAdapter(SourceAdapter):
         limit=None,
         verbose=False,
         warning=False,
+        auth_token=None,
     ):
         super().__init__(
             server_url=server_url,
@@ -948,6 +951,7 @@ class ExposurelogAdapter(SourceAdapter):
             limit=limit,
             verbose=verbose,
             warning=warning,
+            auth_token=auth_token,
         )
 
         # status[endpoint] = dict(endpoint_url, number_of_records, error)

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -74,7 +74,7 @@ async def read_exposures(
                     f"{dayObsStart}, end: {dayObsEnd} "
                     f"and instrument: {instrument}")
     try:
-        exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token)
+        exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
         total_exposure_time = sum(exposure["exp_time"] for exposure in exposures)
         return {
             "exposures": exposures,
@@ -133,7 +133,7 @@ async def read_narrative_log(
     logger.info(f"Getting Narrative Log records for dayObsStart: {dayObsStart}, "
                 f"dayObsEnd: {dayObsEnd} and instrument: {instrument}")
     try:
-        records = get_messages(dayObsStart, dayObsEnd, "LSSTComCam", auth_token)
+        records = get_messages(dayObsStart, dayObsEnd, "LSSTComCam", auth_token=auth_token)
         time_lost_to_weather = sum(msg["time_lost"] for msg in records if msg["time_lost_type"] == 'weather')
         time_lost_to_faults = sum(msg["time_lost"] for msg in records if msg["time_lost_type"] == 'fault')
         return {
@@ -156,7 +156,7 @@ async def read_exposure_flags(
     logger.info(f"Getting Exposure Log flags for dayObsStart: {dayObsStart}, "
                 f"dayObsEnd: {dayObsEnd} and instrument: {instrument}")
     try:
-        flags = get_exposure_flags(dayObsStart, dayObsEnd, instrument, auth_token)
+        flags = get_exposure_flags(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
         return {
             "exposure_flags": flags,
         }

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, Request, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from lsst.ts.logging_and_reporting.exceptions import ConsdbQueryError, BaseLogrepError
+from lsst.ts.logging_and_reporting.utils import get_access_token
 
 from .services.jira_service import get_jira_tickets
 from .services.consdb_service import get_mock_exposures, get_exposures
@@ -30,12 +31,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-def get_auth_token(request: Request):
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or " " not in auth_header:
-        raise HTTPException(status_code=401, detail="Authorization header missing or invalid")
-    return auth_header.split(" ")[1]
 
 
 logger.info("Starting FastAPI app")
@@ -68,7 +63,7 @@ async def read_exposures(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_auth_token),
+    auth_token: str = Depends(get_access_token),
 ):
     logger.info(f"Getting exposures for start: "
                     f"{dayObsStart}, end: {dayObsEnd} "
@@ -128,7 +123,7 @@ async def read_narrative_log(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_auth_token),
+    auth_token: str = Depends(get_access_token),
 ):
     logger.info(f"Getting Narrative Log records for dayObsStart: {dayObsStart}, "
                 f"dayObsEnd: {dayObsEnd} and instrument: {instrument}")
@@ -151,7 +146,7 @@ async def read_exposure_flags(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_auth_token),
+    auth_token: str = Depends(get_access_token),
 ):
     logger.info(f"Getting Exposure Log flags for dayObsStart: {dayObsStart}, "
                 f"dayObsEnd: {dayObsEnd} and instrument: {instrument}")

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -151,11 +151,12 @@ async def read_exposure_flags(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
+    auth_token: str = Depends(get_auth_token),
 ):
     logger.info(f"Getting Exposure Log flags for dayObsStart: {dayObsStart}, "
                 f"dayObsEnd: {dayObsEnd} and instrument: {instrument}")
     try:
-        flags = get_exposure_flags(dayObsStart, dayObsEnd, instrument)
+        flags = get_exposure_flags(dayObsStart, dayObsEnd, instrument, auth_token)
         return {
             "exposure_flags": flags,
         }

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -10,6 +10,7 @@ def get_exposure_flags(
     instrument: str,
     verbose: bool = False,
     limit: int = 2500,
+    auth_token: str = None,
 ) -> list[dict]:
     """
     Get all records with non-empty exposure_flag from the
@@ -39,6 +40,7 @@ def get_exposure_flags(
         max_dayobs=max_dayobs,
         limit=limit,
         verbose=verbose,
+        auth_token=auth_token,
     )
 
     logger.info(f"Fetching exposure flags for instrument: {instrument}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+
+from fastapi import Request, Depends
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from unittest.mock import patch, Mock
+from lsst.ts.logging_and_reporting.utils import get_access_token
+
+app = FastAPI()
+
+@app.get("/test-access-token")
+def access_token_endpoint(
+    request: Request = None,
+    auth_token: str = Depends(get_access_token),
+):
+    return {"token": auth_token}
+
+def test_get_access_token_env_variable(monkeypatch):
+    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
+    token = get_access_token()
+    assert token == "env_token"
+
+def test_get_access_token_rsp_utils():
+    mock_lsst = Mock()
+    mock_lsst.rsp.utils.get_info.return_value = "mocked-token"
+
+    with patch.dict("sys.modules", {
+        "lsst": mock_lsst,
+        "lsst.rsp.utils": mock_lsst.rsp.utils,
+    }):
+        token = get_access_token()
+        assert token == "mocked-token"
+
+def test_get_access_token_request_headers(monkeypatch):
+    monkeypatch.delenv("ACCESS_TOKEN", raising=False)
+    client = TestClient(app)
+    response = client.get(
+        "/test-access-token",
+        headers={"Authorization": "Bearer header_token"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"token": "header_token"}
+
+def test_get_access_token_no_token(monkeypatch):
+    monkeypatch.delenv("ACCESS_TOKEN", raising=False)
+    client = TestClient(app)
+    response = client.get("/test-access-token")
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": "RSP authentication token could not be retrieved by any method."
+    }


### PR DESCRIPTION
This PR adds a FastAPI dependency to inject the authentication token on endpoints that require RSP authentication. This is an effort to provide an easier way of hooking up auth on our current webapp endpoints.