### PR TITLE
OSW-579 Efficiency card doesn't count for multiple nights

### DIFF
--- a/doc/news/OSW-556.feature.1.rst
+++ b/doc/news/OSW-556.feature.1.rst
@@ -1,0 +1,1 @@
+Change creation and updated date formats for tickets returned by the Jira adapter and add a flag to indicate if the ticket was created within the selected dayobs range.

--- a/doc/news/OSW-556.feature.rst
+++ b/doc/news/OSW-556.feature.rst
@@ -1,0 +1,1 @@
+Update JQL in the Jira adapter to retrieve tickets created or updated within the selected dayobs range.

--- a/doc/news/OSW-579-bugfix.rst
+++ b/doc/news/OSW-579-bugfix.rst
@@ -1,0 +1,1 @@
+Count for multiple nights when returning night hours in the almanac service to correct telescope efficiency calculation in frontend. The service now iterates over the dayobs range and sums night hours for each day.

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -8,7 +8,7 @@ from lsst.ts.logging_and_reporting.utils import get_access_token
 
 from .services.jira_service import get_jira_tickets
 from .services.consdb_service import get_mock_exposures, get_exposures
-from .services.almanac_service import get_almanac
+from .services.almanac_service import get_almanac_night_hours
 from .services.narrativelog_service import get_messages
 from .services.exposurelog_service import get_exposure_flags
 
@@ -110,8 +110,8 @@ async def read_jira_tickets(
 async def read_almanac(request: Request, dayObsStart: int, dayObsEnd: int):
     logger.info(f"Getting alamanc for dayObsStart: {dayObsStart}, dayObsEnd: {dayObsEnd}")
     try:
-        almanac = get_almanac(dayObsStart, dayObsEnd)
-        return {"night_hours": almanac.night_hours}
+        night_hours = get_almanac_night_hours(dayObsStart, dayObsEnd)
+        return {"night_hours": night_hours}
     except Exception as e:
         logger.error(f"Error in /almanac: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
@@ -1,10 +1,28 @@
 import logging
+import traceback
+from datetime import datetime, timedelta
+
 from lsst.ts.logging_and_reporting.almanac import Almanac
 
 logger = logging.getLogger(__name__)
 
 
-def get_almanac(dayobs_start: int, dayobs_end: int) -> list:
+def get_almanac_night_hours(dayobs_start: int, dayobs_end: int) -> list:
     logger.info(f"Getting almanac for start: {dayobs_start}, end: {dayobs_end}")
-    almanac = Almanac(min_dayobs=dayobs_start, max_dayobs=dayobs_end)
-    return almanac
+    try:
+        start = datetime.strptime(str(dayobs_start), '%Y%m%d')
+        end = datetime.strptime(str(dayobs_end), '%Y%m%d')
+
+        # calculate night hours for each day in the range
+        current = start
+        total_night_hours = 0.0
+        while current <= end:
+            dayobs = int(current.strftime('%Y%m%d'))
+            almanac = Almanac(min_dayobs=dayobs_start, max_dayobs=dayobs)
+            total_night_hours += almanac.night_hours
+            current += timedelta(days=1)
+        return total_night_hours
+    except Exception as e:
+        traceback.print_exc()
+        logger.error(f"Error fetching almanac data for: {dayobs_start}, {dayobs_end}. Error: {e}")
+        raise e

--- a/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from datetime import datetime
 
 from lsst.ts.logging_and_reporting.jira import JiraAdapter
 
@@ -42,6 +43,14 @@ def filter_tickets_by_instrument(tickets, instrument):
         matched = any(term in system for term in search_terms for system in obj_system_list)
         if matched:
             ticket['url'] = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{ticket.get('key')}"
+            ticket['created'] = (
+                datetime.strptime(ticket['created'], "%Y-%m-%dT%H:%M:%S").strftime("%Y-%m-%d %H:%M:%S")
+                if ticket.get('created') not in (None, "") else ""
+            )
+            ticket['updated'] = (
+                datetime.strptime(ticket['updated'], "%Y-%m-%dT%H:%M:%S.%f%z").strftime("%Y-%m-%d %H:%M:%S")
+                if ticket.get('updated') not in (None, "") else ""
+            )
             return True
         return False
 

--- a/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
@@ -1,6 +1,4 @@
-import os
 import logging
-from datetime import datetime
 
 from lsst.ts.logging_and_reporting.jira import JiraAdapter
 
@@ -35,26 +33,15 @@ def filter_tickets_by_instrument(tickets, instrument):
         each with an added 'url' field.
     """
 
-    def matches_and_add_url(ticket):
+    def matches(ticket):
         # Get the list of systems from the object
         obj_system_list = ticket['system']
         search_terms = (instrument, INSTRUMENTS[instrument])
         # Check if any search term appears in any system name
         matched = any(term in system for term in search_terms for system in obj_system_list)
-        if matched:
-            ticket['url'] = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{ticket.get('key')}"
-            ticket['created'] = (
-                datetime.strptime(ticket['created'], "%Y-%m-%dT%H:%M:%S").strftime("%Y-%m-%d %H:%M:%S")
-                if ticket.get('created') not in (None, "") else ""
-            )
-            ticket['updated'] = (
-                datetime.strptime(ticket['updated'], "%Y-%m-%dT%H:%M:%S.%f%z").strftime("%Y-%m-%d %H:%M:%S")
-                if ticket.get('updated') not in (None, "") else ""
-            )
-            return True
-        return False
+        return matched
 
-    return [ticket for ticket in tickets if matches_and_add_url(ticket)]
+    return [ticket for ticket in tickets if matches(ticket)]
 
 
 

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -98,4 +98,4 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
     assert isinstance(result, list)
     assert result[0]["key"] == "OBS-999"
     assert result[0]["system"] == ["Simonyi"]
-    assert result[0]["updated"] == "2025-01-01T12:00:00.000Z"
+    assert result[0]["updated"] == "2025-01-01 12:00:00"

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -77,8 +77,8 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
                 "key": "OBS-999",
                 "fields": {
                     "summary": "Test issue",
-                    "updated": "2025-01-01 12:00:00",
-                    "created": "2025-01-01 11:00:00",
+                    "updated": "2025-01-01T12:00:00.000Z",
+                    "created": "2025-01-01T11:00:00.000Z",
                     "status": {"name": "Open"},
                     "customfield_10476": [[{"name": "Simonyi"}]],
                 },
@@ -98,4 +98,4 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
     assert isinstance(result, list)
     assert result[0]["key"] == "OBS-999"
     assert result[0]["system"] == ["Simonyi"]
-    assert result[0]["updated"] == "2025-01-01 12:00:00"
+    assert result[0]["updated"] == "2025-01-01T12:00:00.000Z"

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -77,8 +77,8 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
                 "key": "OBS-999",
                 "fields": {
                     "summary": "Test issue",
-                    "updated": "2025-01-01T12:00:00.000Z",
-                    "created": "2025-01-01T11:00:00.000Z",
+                    "updated": "2025-01-01 12:00:00",
+                    "created": "2025-01-01 11:00:00",
                     "status": {"name": "Open"},
                     "customfield_10476": [[{"name": "Simonyi"}]],
                 },
@@ -98,4 +98,4 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
     assert isinstance(result, list)
     assert result[0]["key"] == "OBS-999"
     assert result[0]["system"] == ["Simonyi"]
-    assert result[0]["updated"] == "2025-01-01T12:00:00.000Z"
+    assert result[0]["updated"] == "2025-01-01 12:00:00"


### PR DESCRIPTION
Count for multiple nights when returning night hours in the almanac service to correct telescope efficiency calculation in frontend. The service now iterates over the dayobs range and sums night hours for each day.