### PR TITLE
Add auth to get_exposurelog_entries in exposurelog service

### DIFF
--- a/doc/news/OSW-704.bugfix.rst
+++ b/doc/news/OSW-704.bugfix.rst
@@ -1,0 +1,1 @@
+Add auth token to exposure log service get_exposurelog_entries

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -77,6 +77,7 @@ def get_exposurelog_entries(
     instrument: str,
     verbose: bool = False,
     limit: int = 2500,
+    auth_token: str = None,
 ) -> list[dict]:
     """
     Fetch all Exposure Log entries for an instrument and dayobs range.
@@ -86,6 +87,7 @@ def get_exposurelog_entries(
         max_dayobs=max_dayobs,
         limit=limit,
         verbose=verbose,
+        auth_token=auth_token,
     )
 
     # Get records

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -18,16 +18,18 @@ def get_exposure_flags(
 
     Parameters
     ----------
-    min_dayobs : str
+    min_dayobs : `str`
         Inclusive lower bound for day_obs (e.g., "2025-06-01").
-    max_dayobs : str
+    max_dayobs : `str`
         Exclusive upper bound for day_obs (e.g., "2025-06-03").
-    instrument : str
+    instrument : `str`
         Instrument to filter by (e.g., "LSSTComCam").
-    verbose : bool
+    verbose : `bool`
         Enable verbose logging/debugging.
-    limit : int
+    limit : `int`
         Maximum number of records to request per page (default 2500).
+    auth_token: `str`
+        Authorization token to be passed to the ExposurelogAdapter.
 
     Returns
     -------
@@ -81,6 +83,26 @@ def get_exposurelog_entries(
 ) -> list[dict]:
     """
     Fetch all Exposure Log entries for an instrument and dayobs range.
+
+    Parameters
+    ----------
+    min_dayobs : `str`
+        Inclusive lower bound for day_obs (e.g., "2025-06-01").
+    max_dayobs : `str`
+        Exclusive upper bound for day_obs (e.g., "2025-06-03").
+    instrument : `str`
+        Instrument to filter by (e.g., "LSSTComCam").
+    verbose : `bool`
+        Enable verbose logging/debugging.
+    limit : `int`
+        Maximum number of records to request per page (default 2500).
+    auth_token: `str`
+        Authorization token to be passed to the ExposurelogAdapter.
+
+    Returns
+    -------
+    List[dict]
+        List of each Exposure Log entry, each a dict.
     """
     adapter = ExposurelogAdapter(
         min_dayobs=min_dayobs,


### PR DESCRIPTION
What does doing a hotfix allow us to skip? We should clarify the hotfix process. 

This PR adds the auth token passing through on the exposurelog adapter initialization in the function that the data log page calls. 