### PR TITLE
OSW-831: Fix narrative-log endpoint to follow observing day definition.

### DIFF
--- a/doc/news/OSW-831.bugfix.rst
+++ b/doc/news/OSW-831.bugfix.rst
@@ -1,0 +1,1 @@
+Fix narrative-log endpoint to follow observing day definition.

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -793,7 +793,7 @@ class NarrativelogAdapter(SourceAdapter):
 
         LSST_DAYOBS = 20250120
         for rec in records:
-            dayobs = int(rec["date_added"][:8].replace("-", ""))
+            dayobs = int(rec["date_added"][:10].replace("-", ""))
             if rec["components_json"] is None:
                 instrument = None
             elif rec["components_json"].get("name") == "AuxTel":
@@ -851,11 +851,11 @@ class NarrativelogAdapter(SourceAdapter):
             qparams["message_text"] = message_text
         if self.min_date:
             qparams["min_date_added"] = dt.datetime.combine(
-                self.min_date, dt.time()
+                self.min_date, dt.time(12, 0)
             ).isoformat()
         if self.max_date:
             qparams["max_date_added"] = dt.datetime.combine(
-                self.max_date, dt.time()
+                self.max_date, dt.time(11, 59, 59)
             ).isoformat()
 
         error = None

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -841,7 +841,7 @@ class NarrativelogAdapter(SourceAdapter):
         qparams = dict(
             is_human=is_human,
             is_valid=is_valid,
-            order_by="-date_added",
+            order_by="-date_begin",
             offset=0,
             limit=self.limit,
         )
@@ -850,11 +850,11 @@ class NarrativelogAdapter(SourceAdapter):
         if message_text:
             qparams["message_text"] = message_text
         if self.min_date:
-            qparams["min_date_added"] = dt.datetime.combine(
+            qparams["min_date_begin"] = dt.datetime.combine(
                 self.min_date, dt.time(12, 0)
             ).isoformat()
         if self.max_date:
-            qparams["max_date_added"] = dt.datetime.combine(
+            qparams["max_date_begin"] = dt.datetime.combine(
                 self.max_date, dt.time(11, 59, 59)
             ).isoformat()
 

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -782,18 +782,28 @@ class NarrativelogAdapter(SourceAdapter):
         exposures.
         Therefore, we must map Telescope to the Instrument that is assumed to
         be on the Telescope.
-        We always assume Telescope=AuxTel means Instrument=LATISS
+        We always assume Telescope=AuxTel means Instrument=LATISS.
         For Telescope=MainTel (aka Simonyi) the Instrument assumed is different
-        depending on the dayobs.
-        Prior to dayobs=2025-01-19 we assume Instrument=LSSTComCam
-          from then on we assume Instrument=LSSTCam.
+        depending on the date when the log was added.
+        Prior to 2025-01-19 we assume Instrument=LSSTComCam
+        from then on we assume Instrument=LSSTCam.
         For any Telescope value other than AuxTel or MainTel we ignore the data
-          (but warn about what Telescope we are ignoring).
+        (but warn about what Telescope we are ignoring).
+
+        Parameters
+        ----------
+        records : `list` [`dict`]
+            List of records to process.
+
+        Returns
+        -------
+        updated_records : `list` [`dict`]
+            List of records with 'instrument' field added.
         """
 
-        LSST_DAYOBS = 20250120
+        LSST_DAY = 20250120
         for rec in records:
-            dayobs = int(rec["date_added"][:10].replace("-", ""))
+            day_added = int(rec["date_added"][:10].replace("-", ""))
             if rec["components_json"] is None:
                 instrument = None
             elif rec["components_json"].get("name") == "AuxTel":
@@ -815,12 +825,14 @@ class NarrativelogAdapter(SourceAdapter):
                     "Expected one of {AuxTel, MainTel, Simonyi} "
                     f"got {components=}. "
                 )
-                warnings.warn(msg, category=ex.UnknownTelescopeWarning, stacklevel=2)
+                warnings.warn(
+                    msg, category=ex.UnknownTelescopeWarning, stacklevel=2
+                )
 
             if instrument == "lsst":
-                if dayobs >= LSST_DAYOBS:
+                if day_added >= LSST_DAY:
                     rec["instrument"] = "LSSTCam"
-                else:  # dayobs < LSST_DAYOBS
+                else:
                     rec["instrument"] = "LSSTComCam"
             else:
                 rec["instrument"] = instrument

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -168,7 +168,7 @@ async def read_narrative_log(
     )
     try:
         records = get_messages(
-            dayObsStart, dayObsEnd, "LSSTComCam", auth_token=auth_token
+            dayObsStart, dayObsEnd, instrument, auth_token=auth_token
         )
         time_lost_to_weather = sum(
             msg["time_lost"] for msg in records if msg["time_lost_type"] == "weather"


### PR DESCRIPTION
This PR makes some fixes and adjustments to the implementation of the narrative-log endpoint in order to properly set the time range to query logs.