### PR TITLE
OSW-850: get BLOCK details from Zephyr and Jira

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -51,6 +51,7 @@ requirements:
         - rubin-sim =2.6
         - bokeh =3
         - lsst-efd-client =0.12
+        - ts-planning-tool =0.1
         - scikit-learn
         - psycopg2 =2.9
         - astropy-iers-data

--- a/doc/news/OSW-850.feature.rst
+++ b/doc/news/OSW-850.feature.rst
@@ -1,1 +1,1 @@
-Add Zephyr test case service and API endpoint
+Add Zephyr/Jira BLOCK services and API endpoint

--- a/doc/news/OSW-850.feature.rst
+++ b/doc/news/OSW-850.feature.rst
@@ -1,0 +1,1 @@
+Add Zephyr test case service and API endpoint

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN chown -R saluser:saluser /home/saluser/develop
 USER saluser
 
 RUN source /home/saluser/.setup_dev.sh && \
+	pip install git+https://github.com/lsst-ts/ts_planning_tool.git@develop && \
 	# install this package
 	pip install -e .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,6 @@ RUN chown -R saluser:saluser /home/saluser/develop
 USER saluser
 
 RUN source /home/saluser/.setup_dev.sh && \
-	pip install git+https://github.com/lsst-ts/ts_planning_tool.git@develop && \
 	# install this package
 	pip install -e .
 

--- a/python/lsst/ts/logging_and_reporting/jira.py
+++ b/python/lsst/ts/logging_and_reporting/jira.py
@@ -170,3 +170,54 @@ class JiraAdapter:
             }
             for issue in issues
         ]
+
+
+# Separate stateless Jira Adapter that does not require a dayobs range.
+class JiraClient:
+    def __init__(self):
+        self.base_url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
+        self.headers = {
+            "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
+            "content-type": "application/json",
+        }
+
+    def _search(self, jql_query, fields):
+        url = f"{self.base_url}/rest/api/latest/search/jql?jql={quote(jql_query)}&fields={fields}"
+
+        try:
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            msg = f"Error querying Jira: {response.status_code} - {response.text}"
+            traceback.print_exc()
+            raise ex.BaseLogrepError(msg) from err
+        except requests.exceptions.ConnectionError as err:
+            msg = f"Error connecting to Jira. {str(err)}"
+            traceback.print_exc()
+            raise ex.BaseLogrepError(msg) from err
+
+        return response.json().get("issues", [])
+
+    def fetch_block_ticket_summaries(self, ticket_keys):
+        """
+        Fetch summary fields for a list of BLOCK tickets.
+
+        Parameters
+        ----------
+        ticket_keys : list[str]
+            List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"])
+
+        Returns
+        -------
+        dict
+            Mapping of ticket key -> summary
+        """
+        if not ticket_keys:
+            return {}
+
+        keys_str = ",".join(ticket_keys)
+        jql_query = f"project = BLOCK AND key in ({keys_str})"
+
+        issues = self._search(jql_query, fields="summary")
+
+        return {issue["key"]: issue["fields"]["summary"] for issue in issues}

--- a/python/lsst/ts/logging_and_reporting/jira.py
+++ b/python/lsst/ts/logging_and_reporting/jira.py
@@ -171,46 +171,18 @@ class JiraAdapter:
             for issue in issues
         ]
 
-
-# Separate stateless Jira Adapter that does not require a dayobs range.
-class JiraClient:
-    def __init__(self):
-        self.base_url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}"
-        self.headers = {
-            "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
-            "content-type": "application/json",
-        }
-
-    def _search(self, jql_query, fields):
-        url = f"{self.base_url}/rest/api/latest/search/jql?jql={quote(jql_query)}&fields={fields}"
-
-        try:
-            response = requests.get(url, headers=self.headers)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            msg = f"Error querying Jira: {response.status_code} - {response.text}"
-            traceback.print_exc()
-            raise ex.BaseLogrepError(msg) from err
-        except requests.exceptions.ConnectionError as err:
-            msg = f"Error connecting to Jira. {str(err)}"
-            traceback.print_exc()
-            raise ex.BaseLogrepError(msg) from err
-
-        return response.json().get("issues", [])
-
     def fetch_block_ticket_summaries(self, ticket_keys):
-        """
-        Fetch summary fields for a list of BLOCK tickets.
+        """Fetch summary fields for a list of BLOCK tickets.
 
         Parameters
         ----------
-        ticket_keys : list[str]
-            List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"])
+        ticket_keys : `list` [`str`]
+            List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"]).
 
         Returns
         -------
-        dict
-            Mapping of ticket key -> summary
+        `dict`
+            Mapping of ticket key -> summary.
         """
         if not ticket_keys:
             return {}

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -59,8 +59,8 @@ AUTH_SOURCES = {
 }
 
 # Base urls for BLOCK links
-ZEPHYR_BLOCK_BASE_URL = "https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCase/"
-JIRA_BLOCK_BASE_URL = "https://rubinobs.atlassian.net/browse/"
+ZEPHYR_BLOCK_BASE_URL = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCase/"
+JIRA_BLOCK_BASE_URL = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/"
 
 
 def date_hr_min(iso_dt_str):
@@ -329,7 +329,7 @@ def retrieve_access_token(config: dict, request: Request = None) -> str:
 
     Returns
     -------
-    str
+    `str`
         The resolved authentication token.
 
     Raises
@@ -430,7 +430,7 @@ def get_access_token(source: str = "rsp"):
 
         Returns
         -------
-        str
+        `str`
             Authentication token retrieved using ``retrieve_access_token``.
 
         Raises
@@ -453,7 +453,7 @@ def get_auth_header(token: str | None):
 
     Returns
     -------
-    dict
+    `dict`
         A dictionary containing the ``Authorization`` header with the
         bearer token.
 
@@ -482,7 +482,7 @@ def get_jira_hostname():
 
     Returns
     -------
-    str
+    `str`
         The Jira API hostname.
 
     Raises

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -58,6 +58,10 @@ AUTH_SOURCES = {
     },
 }
 
+# Base urls for BLOCK links
+ZEPHYR_BLOCK_BASE_URL = "https://rubinobs.atlassian.net/projects/BLOCK?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCase/"
+JIRA_BLOCK_BASE_URL = "https://rubinobs.atlassian.net/browse/"
+
 
 def date_hr_min(iso_dt_str):
     # return YYYY-MM-DD HH:MM
@@ -609,3 +613,53 @@ def make_json_safe(obj):
         return None if (math.isnan(obj) or math.isinf(obj)) else obj
 
     return obj
+
+
+def build_block_response(zephyr_data, jira_data):
+    """Construct a unified response object for BLOCK details.
+
+    Combines Zephyr and Jira BLOCK data into a single dictionary keyed by
+    BLOCK identifier. Each entry includes the key, summary, source, and a
+    correctly formatted URL. Zephyr BLOCK URLs are derived from the parent
+    key (i.e., suffixes after "_" are removed), while Jira BLOCK URLs use
+    the full key.
+
+    Parameters
+    ----------
+    zephyr_data : dict
+        Mapping of Zephyr BLOCK keys to summaries.
+    jira_data : dict
+        Mapping of Jira BLOCK keys to summaries.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping each BLOCK key to a JSON-serializable object
+        containing:
+        - "key": str
+        - "summary": str
+        - "source": "zephyr" or "jira"
+        - "url": str
+    """
+    result = {}
+
+    for key, summary in zephyr_data.items():
+        # Test cases with _# at the end are represented in
+        # Zephyr Scale without the _# at the end.
+        parent_key = key.split("_", 1)[0]
+        result[key] = {
+            "key": key,
+            "summary": summary,
+            "source": "zephyr",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}{parent_key}",
+        }
+
+    for key, summary in jira_data.items():
+        result[key] = {
+            "key": key,
+            "summary": summary,
+            "source": "jira",
+            "url": f"{JIRA_BLOCK_BASE_URL}{key}",
+        }
+
+    return result

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -517,7 +517,7 @@ async def read_block_details(
     ------
     HTTPException
         Raised with status code 500 if an unexpected error occurs while
-        retrieving test case details.
+        retrieving BLOCK details.
     """
     logger.info(f"Getting BLOCK details from Zephyr/Jira for {key}")
     try:

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -1,8 +1,9 @@
 import logging
 from datetime import datetime, timedelta
+from typing import List
 
 from bokeh.embed import json_item
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -33,6 +34,7 @@ from .services.rubin_nights_service import (
     get_visits,
 )
 from .services.scheduler_service import create_visit_skymaps, get_expected_exposures, prepare_visit_maps_data
+from .services.zephyr_service import get_test_cases
 
 # Auth dependencies (instantiated once for reuse and testing)
 rsp_auth = get_access_token()
@@ -485,4 +487,42 @@ async def survey_progress_map(
         return {"static": json_item(s_map) if s_map is not None else {}}
     except Exception as e:
         logger.error(f"Error in /survey-progress-map: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/test-cases")
+async def read_test_cases(
+    request: Request,
+    key: List[str] = Query(...),
+    auth_token: str = Depends(get_access_token),
+):
+    """Retrieve Zephyr Scale test case details for a list of test case keys.
+    Parameters
+    ----------
+    request : `Request`
+        FastAPI request object.
+    key : `List[str]`
+        List of Zephyr test case keys (e.g., ``BLOCK-T123`` or
+        ``BLOCK-T123_a``) provided as query parameters.
+    auth_token : `str`
+        Authentication token (injected by FastAPI dependency).
+    Returns
+    -------
+    `dict`
+        A dictionary containing a ``data`` field that maps each valid
+        input test case key to its corresponding Zephyr test case name.
+    Raises
+    ------
+    HTTPException
+        Raised with status code 500 if an unexpected error occurs while
+        retrieving test case details.
+    """
+    logger.info(f"Getting Zephyr test case details for {key}")
+    try:
+        test_cases = await get_test_cases(key)
+        return {
+            "data": test_cases,
+        }
+    except Exception as e:
+        logger.error(f"Error in /test-cases: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -12,10 +12,10 @@ from rubin_scheduler.scheduler.model_observatory import ModelObservatory
 
 from lsst.ts.logging_and_reporting.exceptions import BaseLogrepError, ConsdbQueryError
 from lsst.ts.logging_and_reporting.utils import (
+    build_block_response,
     get_access_token,
     get_jira_hostname,
     make_json_safe,
-    build_block_response,
 )
 
 from .. import __version__
@@ -41,6 +41,7 @@ from .services.zephyr_service import get_test_cases
 # Auth dependencies (instantiated once for reuse and testing)
 rsp_auth = get_access_token()
 jira_auth = get_access_token("jira")
+zephyr_auth = get_access_token("zephyr")
 
 logger = logging.getLogger("uvicorn.error")
 logger.setLevel(logging.DEBUG)
@@ -495,31 +496,40 @@ async def survey_progress_map(
 @app.get("/block-details")
 async def read_block_details(
     request: Request,
-    key: List[str] = Query(...),
-    auth_token: str = Depends(get_access_token),
+    keys: List[str] = Query(..., alias="key"),
+    zephyr_token: str = Depends(zephyr_auth),
+    jira_token: str = Depends(jira_auth),
+    jira_hostname: str = Depends(get_jira_hostname),
 ):
     """Retrieve BLOCK details from Zephyr/Jira for a list of keys.
+
     Parameters
     ----------
-    request : `Request`
+    request : `fastapi.Request`
         FastAPI request object.
-    key : `List[str]`
+    key : `list` [`str`]
         List of BLOCK keys (e.g., ``BLOCK-704`` or
         ``BLOCK-T123_a``) provided as query parameters.
-    auth_token : `str`
-        Authentication token (injected by FastAPI dependency).
+    zephyr_token : `str`
+        Authentication token for Zephyr (injected by FastAPI dependency).
+    jira_token : `str`
+        Authentication token for Jira (injected by FastAPI dependency).
+    jira_hostname : `str`
+        Authentication hostname for Jira (injected by FastAPI dependency).
+
     Returns
     -------
     `dict`
         A dictionary containing a ``data`` field that maps each valid BLOCK key
         to its associated summary, URL, and source (e.g., Zephyr or Jira).
+
     Raises
     ------
     HTTPException
         Raised with status code 500 if an unexpected error occurs while
         retrieving BLOCK details.
     """
-    logger.info(f"Getting BLOCK details from Zephyr/Jira for {key}")
+    logger.info(f"Getting BLOCK details from Zephyr/Jira for: {keys}")
     try:
         ZEPHYR_BLOCK_RE = re.compile(r"^BLOCK-T\d+(?:_[A-Za-z0-9]+)?$")
         JIRA_BLOCK_RE = re.compile(r"^BLOCK-\d+$")
@@ -528,7 +538,7 @@ async def read_block_details(
         jira_keys = []
 
         # Remove duplicates
-        key = list(dict.fromkeys(key))
+        key = list(dict.fromkeys(keys))
 
         # Sort keys by data source
         for k in key:
@@ -546,7 +556,11 @@ async def read_block_details(
         if zephyr_keys:
             try:
                 logger.info(f"Getting Test Case BLOCK details from Zephyr for {zephyr_keys}")
-                zephyr_blocks = await get_test_cases(zephyr_keys)
+                zephyr_blocks = await get_test_cases(
+                    zephyr_keys,
+                    zephyr_token=zephyr_token,
+                    jira_token=jira_token,
+                )
             except Exception as e:
                 logger.error(f"Zephyr error in /block-details: {e}", exc_info=True)
                 errors["zephyr"] = str(e)
@@ -555,13 +569,17 @@ async def read_block_details(
         if jira_keys:
             try:
                 logger.info(f"Getting BLOCK ticket summaries from Jira for {jira_keys}")
-                jira_blocks = get_block_ticket_summaries(jira_keys)
+                jira_blocks = get_block_ticket_summaries(
+                    jira_keys,
+                    jira_token=jira_token,
+                    jira_hostname=jira_hostname,
+                )
             except Exception as e:
                 logger.error(f"Jira error in /block-details: {e}", exc_info=True)
                 errors["jira"] = str(e)
 
         # If both failed → hard fail
-        if ("zephyr" in errors) and ("jira" in errors):
+        if "zephyr" in errors and "jira" in errors:
             raise HTTPException(status_code=500, detail="Both Zephyr and Jira requests failed.")
 
         # Flesh out response dict with source type and URL

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime, timedelta
 from typing import List
 
@@ -14,6 +15,7 @@ from lsst.ts.logging_and_reporting.utils import (
     get_access_token,
     get_jira_hostname,
     make_json_safe,
+    build_block_response,
 )
 
 from .. import __version__
@@ -24,7 +26,7 @@ from .services.consdb_service import (
     get_mock_exposures,
 )
 from .services.exposurelog_service import get_exposure_flags, get_exposurelog_entries
-from .services.jira_service import get_jira_tickets
+from .services.jira_service import get_block_ticket_summaries, get_jira_tickets
 from .services.narrativelog_service import get_messages
 from .services.nightreport_service import get_night_reports
 from .services.rubin_nights_service import (
@@ -490,39 +492,91 @@ async def survey_progress_map(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/test-cases")
-async def read_test_cases(
+@app.get("/block-details")
+async def read_block_details(
     request: Request,
     key: List[str] = Query(...),
     auth_token: str = Depends(get_access_token),
 ):
-    """Retrieve Zephyr Scale test case details for a list of test case keys.
+    """Retrieve BLOCK details from Zephyr/Jira for a list of keys.
     Parameters
     ----------
     request : `Request`
         FastAPI request object.
     key : `List[str]`
-        List of Zephyr test case keys (e.g., ``BLOCK-T123`` or
+        List of BLOCK keys (e.g., ``BLOCK-704`` or
         ``BLOCK-T123_a``) provided as query parameters.
     auth_token : `str`
         Authentication token (injected by FastAPI dependency).
     Returns
     -------
     `dict`
-        A dictionary containing a ``data`` field that maps each valid
-        input test case key to its corresponding Zephyr test case name.
+        A dictionary containing a ``data`` field that maps each valid BLOCK key
+        to its associated summary, URL, and source (e.g., Zephyr or Jira).
     Raises
     ------
     HTTPException
         Raised with status code 500 if an unexpected error occurs while
         retrieving test case details.
     """
-    logger.info(f"Getting Zephyr test case details for {key}")
+    logger.info(f"Getting BLOCK details from Zephyr/Jira for {key}")
     try:
-        test_cases = await get_test_cases(key)
+        ZEPHYR_BLOCK_RE = re.compile(r"^BLOCK-T\d+(?:_[A-Za-z0-9]+)?$")
+        JIRA_BLOCK_RE = re.compile(r"^BLOCK-\d+$")
+
+        zephyr_keys = []
+        jira_keys = []
+
+        # Remove duplicates
+        key = list(dict.fromkeys(key))
+
+        # Sort keys by data source
+        for k in key:
+            if ZEPHYR_BLOCK_RE.match(k):
+                zephyr_keys.append(k)
+            elif JIRA_BLOCK_RE.match(k):
+                jira_keys.append(k)
+
+        zephyr_blocks = {}
+        jira_blocks = {}
+
+        errors = {}
+
+        # Get BLOCK descriptions from Zephyr
+        if zephyr_keys:
+            try:
+                logger.info(f"Getting Test Case BLOCK details from Zephyr for {zephyr_keys}")
+                zephyr_blocks = await get_test_cases(zephyr_keys)
+            except Exception as e:
+                logger.error(f"Zephyr error in /block-details: {e}", exc_info=True)
+                errors["zephyr"] = str(e)
+
+        # Get Test Case BLOCK descriptions from Jira
+        if jira_keys:
+            try:
+                logger.info(f"Getting BLOCK ticket summaries from Jira for {jira_keys}")
+                jira_blocks = get_block_ticket_summaries(jira_keys)
+            except Exception as e:
+                logger.error(f"Jira error in /block-details: {e}", exc_info=True)
+                errors["jira"] = str(e)
+
+        # If both failed → hard fail
+        if ("zephyr" in errors) and ("jira" in errors):
+            raise HTTPException(status_code=500, detail="Both Zephyr and Jira requests failed.")
+
+        # Flesh out response dict with source type and URL
+        data = build_block_response(zephyr_blocks, jira_blocks)
+
         return {
-            "data": test_cases,
+            "data": data,
+            "errors": errors,
         }
+
+    # Catch double service failures
+    except HTTPException:
+        raise
+
+    # Catch other errors
     except Exception as e:
-        logger.error(f"Error in /test-cases: {e}")
+        logger.error(f"Error in /block-details: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from lsst.ts.logging_and_reporting.jira import JiraAdapter, JiraClient
+from lsst.ts.logging_and_reporting.jira import JiraAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -168,19 +168,27 @@ def get_jira_tickets(
     return system_tickets
 
 
-def get_block_ticket_summaries(ticket_keys: list[str]) -> dict:
-    """
-    Fetch summaries for a list of BLOCK Jira tickets.
+def get_block_ticket_summaries(
+    ticket_keys: list[str],
+    jira_token: str = None,
+    jira_hostname: str = None,
+) -> dict:
+    """Fetch summaries for a list of BLOCK Jira tickets.
 
     Parameters
     ----------
-    ticket_keys : list[str]
-        List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"])
+    ticket_keys : `list` [`str`]
+        List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"]).
+    jira_token : `str`, optional
+        Authentication token used when connecting to Rubin Observatory's
+        Jira services.
+    jira_hostname : `str`, optional
+        Hostname for the Jira API.
 
     Returns
     -------
-    dict
-        Mapping of ticket key -> summary
+    `dict`
+        Mapping of ticket key -> summary.
     """
     logger.info(f"Jira service (BLOCK): fetching summaries for {len(ticket_keys)} tickets")
 
@@ -188,7 +196,10 @@ def get_block_ticket_summaries(ticket_keys: list[str]) -> dict:
         logger.warning("No BLOCK ticket keys provided.")
         return {}
 
-    jira = JiraClient()
+    jira = JiraAdapter(
+        jira_token=jira_token,
+        jira_hostname=jira_hostname,
+    )
 
     summaries = jira.fetch_block_ticket_summaries(ticket_keys)
 

--- a/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from lsst.ts.logging_and_reporting.jira import JiraAdapter
+from lsst.ts.logging_and_reporting.jira import JiraAdapter, JiraClient
 
 logger = logging.getLogger(__name__)
 
@@ -166,3 +166,35 @@ def get_jira_tickets(
         )
 
     return system_tickets
+
+
+def get_block_ticket_summaries(ticket_keys: list[str]) -> dict:
+    """
+    Fetch summaries for a list of BLOCK Jira tickets.
+
+    Parameters
+    ----------
+    ticket_keys : list[str]
+        List of Jira issue keys (e.g. ["BLOCK-123", "BLOCK-456"])
+
+    Returns
+    -------
+    dict
+        Mapping of ticket key -> summary
+    """
+    logger.info(f"Jira service (BLOCK): fetching summaries for {len(ticket_keys)} tickets")
+
+    if not ticket_keys:
+        logger.warning("No BLOCK ticket keys provided.")
+        return {}
+
+    jira = JiraClient()
+
+    summaries = jira.fetch_block_ticket_summaries(ticket_keys)
+
+    if not summaries:
+        logger.warning("No BLOCK ticket summaries found.")
+    else:
+        logger.info(f"Fetched {len(summaries)} BLOCK ticket summaries.")
+
+    return summaries

--- a/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
@@ -1,0 +1,62 @@
+import logging
+import os
+import re
+
+from lsst.ts.planning.tool import ZephyrInterface
+
+logger = logging.getLogger("uvicorn.error")
+logger.setLevel(logging.DEBUG)
+
+# Zephyr Scale keys have the form BLOCK-T###[_#]
+VALID_KEY_RE = re.compile(r"^BLOCK-T\d+(?:_[A-Za-z0-9]+)?$")
+
+
+async def get_test_cases(
+    keys: list[str],
+    zephyr: ZephyrInterface | None = None,
+) -> dict:
+    """
+    Retrieve Zephyr Scale test case names for a list of candidate keys.
+    Filters the provided keys against `VALID_KEY_RE` (expected format:
+    ``BLOCK-T###`` or ``BLOCK-T###_<suffix>``). For keys that include a
+    suffix (e.g. ``_a``), only the parent portion (``BLOCK-T###``) is used
+    when querying Zephyr Scale, as suffixed variants are not stored as
+    independent test cases.
+    Authentication credentials are read from the environment variables:
+    ``JIRA_USERNAME``, ``JIRA_API_TOKEN``, and ``ZEPHYR_API_TOKEN``.
+    Parameters
+    ----------
+    keys : `List[str]`
+        List of Zephyr test case keys (e.g., ``BLOCK-T123`` or
+        ``BLOCK-T123_a``).
+    Returns
+    -------
+    `dict`
+        A dictionary mapping each valid input key to its corresponding
+        Zephyr test case name. Invalid keys or keys that fail retrieval
+        are skipped.
+    """
+    valid_keys = [k for k in keys if VALID_KEY_RE.match(k)]
+    logger.info(f"Getting Zephyr test case details for valid keys {valid_keys}")
+
+    # Only construct real ZephyrInterface if not injected
+    if zephyr is None:
+        zephyr = ZephyrInterface(
+            jira_username=os.environ.get("JIRA_USERNAME"),
+            jira_api_token=os.environ.get("JIRA_API_TOKEN"),
+            zephyr_api_token=os.environ.get("ZEPHYR_API_TOKEN"),
+        )
+
+    test_cases = {}
+
+    for key in valid_keys:
+        try:
+            # Test cases with _# at the end are represented in
+            # Zephyr Scale without the _# at the end.
+            parent_key = key.split("_", 1)[0]
+            test_case_details = await zephyr.get_test_case(parent_key)
+            test_cases[key] = test_case_details["name"]
+        except Exception as e:
+            logger.warning(f"Skipping Zephyr test case {key}: {e}")
+
+    return test_cases

--- a/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
@@ -1,14 +1,10 @@
 import logging
 import os
-import re
 
 from lsst.ts.planning.tool import ZephyrInterface
 
 logger = logging.getLogger("uvicorn.error")
 logger.setLevel(logging.DEBUG)
-
-# Zephyr Scale keys have the form BLOCK-T###[_#]
-VALID_KEY_RE = re.compile(r"^BLOCK-T\d+(?:_[A-Za-z0-9]+)?$")
 
 
 async def get_test_cases(
@@ -17,11 +13,9 @@ async def get_test_cases(
 ) -> dict:
     """
     Retrieve Zephyr Scale test case names for a list of candidate keys.
-    Filters the provided keys against `VALID_KEY_RE` (expected format:
-    ``BLOCK-T###`` or ``BLOCK-T###_<suffix>``). For keys that include a
-    suffix (e.g. ``_a``), only the parent portion (``BLOCK-T###``) is used
-    when querying Zephyr Scale, as suffixed variants are not stored as
-    independent test cases.
+    For keys that include a suffix (e.g. ``_a``), only the parent
+    portion (``BLOCK-T###``) is used when querying Zephyr Scale, as
+    suffixed variants are not stored as independent test cases.
     Authentication credentials are read from the environment variables:
     ``JIRA_USERNAME``, ``JIRA_API_TOKEN``, and ``ZEPHYR_API_TOKEN``.
     Parameters
@@ -33,11 +27,9 @@ async def get_test_cases(
     -------
     `dict`
         A dictionary mapping each valid input key to its corresponding
-        Zephyr test case name. Invalid keys or keys that fail retrieval
-        are skipped.
+        Zephyr test case name. Keys that fail retrieval are skipped.
     """
-    valid_keys = [k for k in keys if VALID_KEY_RE.match(k)]
-    logger.info(f"Getting Zephyr test case details for valid keys {valid_keys}")
+    logger.info(f"Getting Zephyr test case details for BLOCK keys {keys}")
 
     # Only construct real ZephyrInterface if not injected
     if zephyr is None:
@@ -49,7 +41,7 @@ async def get_test_cases(
 
     test_cases = {}
 
-    for key in valid_keys:
+    for key in keys:
         try:
             # Test cases with _# at the end are represented in
             # Zephyr Scale without the _# at the end.

--- a/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/zephyr_service.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from lsst.ts.planning.tool import ZephyrInterface
 
@@ -9,20 +8,35 @@ logger.setLevel(logging.DEBUG)
 
 async def get_test_cases(
     keys: list[str],
+    zephyr_token: str = None,
+    jira_token: str = None,
     zephyr: ZephyrInterface | None = None,
 ) -> dict:
-    """
-    Retrieve Zephyr Scale test case names for a list of candidate keys.
+    """Retrieve Zephyr Scale test case names for a list of candidate keys.
+
     For keys that include a suffix (e.g. ``_a``), only the parent
     portion (``BLOCK-T###``) is used when querying Zephyr Scale, as
     suffixed variants are not stored as independent test cases.
+
     Authentication credentials are read from the environment variables:
     ``JIRA_USERNAME``, ``JIRA_API_TOKEN``, and ``ZEPHYR_API_TOKEN``.
+
     Parameters
     ----------
     keys : `List[str]`
         List of Zephyr test case keys (e.g., ``BLOCK-T123`` or
         ``BLOCK-T123_a``).
+    zephyr_token : `str`, optional
+        Authentication token for Zephyr API access. Used when constructing
+        a ``ZephyrInterface`` if one is not provided.
+    jira_token : `str`, optional
+        Authentication token for Jira API access. Used when constructing
+        a ``ZephyrInterface`` if one is not provided.
+    zephyr : `ZephyrInterface`, optional
+        An existing Zephyr interface instance. If provided, this instance
+        is used directly and token arguments are ignored. This is primarily
+        intended for dependency injection and testing.
+
     Returns
     -------
     `dict`
@@ -34,9 +48,8 @@ async def get_test_cases(
     # Only construct real ZephyrInterface if not injected
     if zephyr is None:
         zephyr = ZephyrInterface(
-            jira_username=os.environ.get("JIRA_USERNAME"),
-            jira_api_token=os.environ.get("JIRA_API_TOKEN"),
-            zephyr_api_token=os.environ.get("ZEPHYR_API_TOKEN"),
+            zephyr_api_token=zephyr_token,
+            jira_api_token=jira_token,
         )
 
     test_cases = {}

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -10,7 +10,12 @@ from rubin_nights.connections import get_clients
 
 import lsst.ts.logging_and_reporting.utils as ut
 from lsst.ts.logging_and_reporting import __version__
-from lsst.ts.logging_and_reporting.utils import get_jira_hostname
+from lsst.ts.logging_and_reporting.utils import (
+    JIRA_BLOCK_BASE_URL,
+    ZEPHYR_BLOCK_BASE_URL,
+    get_access_token,
+    get_jira_hostname,
+)
 from lsst.ts.logging_and_reporting.web_app.main import app, jira_auth, rsp_auth
 
 client = TestClient(app)
@@ -1260,17 +1265,27 @@ def test_expected_exposures_endpoint_passes_correct_params(monkeypatch):
     assert called == {"start": 20240101, "end": 20240102}
 
 
-def test_test_cases_endpoint_success(monkeypatch):
-    endpoint = "/test-cases?key=BLOCK-T123&key=BLOCK-T456"
+def test_block_details_endpoint_success(monkeypatch):
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
-    # Dummy response for get_test_cases
+    # Dummy response for get_test_cases (Zephyr)
     async def dummy_get_test_cases(keys, zephyr=None):
-        return {k: f"Name for {k}" for k in keys}
+        return {k: f"Description of {k}" for k in keys}
 
-    # Patch service
+    # Dummy response for get_block_ticket_summaries (Jira)
+    def dummy_get_block_ticket_summaries(keys):
+        return {k: f"Description of {k}" for k in keys}
+
+    # Patch Zephyr service
     monkeypatch.setattr(
         "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
         dummy_get_test_cases,
+    )
+
+    # Patch Jira service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        dummy_get_block_ticket_summaries,
     )
 
     # Override auth token
@@ -1282,24 +1297,39 @@ def test_test_cases_endpoint_success(monkeypatch):
 
     data = response.json()
     assert "data" in data
+    assert "errors" in data
+    # Success for both services
     assert data["data"] == {
-        "BLOCK-T123": "Name for BLOCK-T123",
-        "BLOCK-T456": "Name for BLOCK-T456",
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Description of BLOCK-T123",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+        "BLOCK-456": {
+            "key": "BLOCK-456",
+            "summary": "Description of BLOCK-456",
+            "url": f"{JIRA_BLOCK_BASE_URL}BLOCK-456",
+            "source": "jira",
+        },
     }
+    # No errors collected
+    assert data["errors"] == {}
 
     # Clean up
     app.dependency_overrides.pop(get_access_token, None)
 
 
-def test_test_cases_endpoint_invalid_keys(monkeypatch):
+def test_block_details_endpoint_mixed_invalid_keys(monkeypatch):
     """Invalid keys should be filtered out."""
 
-    endpoint = "/test-cases?key=BLOCK-T123&key=INVALID-1"
+    endpoint = "/block-details?key=BLOCK-T123&key=INVALID-1"
 
+    # Dummy response for get_test_cases (Zephyr)
     async def dummy_get_test_cases(keys, zephyr=None):
-        # Valid keys only
-        return {"BLOCK-T123": "Name for BLOCK-T123"}
+        return {k: f"Description of {k}" for k in keys}
 
+    # Patch Zephyr service
     monkeypatch.setattr(
         "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
         dummy_get_test_cases,
@@ -1310,30 +1340,284 @@ def test_test_cases_endpoint_invalid_keys(monkeypatch):
     response = client.get(endpoint)
     assert response.status_code == 200
     data = response.json()
+    assert "data" in data
+    assert "errors" in data
     # Only valid key returned
     assert "BLOCK-T123" in data["data"]
     assert "INVALID-1" not in data["data"]
+    # No errors collected
+    assert data["errors"] == {}
 
     app.dependency_overrides.pop(get_access_token, None)
 
 
-def test_test_cases_endpoint_service_failure(monkeypatch):
+def test_block_details_endpoint_all_invalid_keys(monkeypatch):
+    """No invalid keys should return an empty dict."""
+
+    endpoint = "/block-details?key=unknown&key=INVALID-1"
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # No keys returned
+    assert "unknown" not in data["data"]
+    assert "INVALID-1" not in data["data"]
+    # No errors collected
+    assert data["errors"] == {}
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_duplicate_keys(monkeypatch):
+    """Duplicate keys should be filtered out."""
+
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-T123"
+
+    # Dummy response for get_test_cases (Zephyr)
+    async def dummy_get_test_cases(keys, zephyr=None):
+        return {k: f"Description of {k}" for k in keys}
+
+    # Patch Zephyr service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        dummy_get_test_cases,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Only one key returned
+    assert data["data"] == {
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Description of BLOCK-T123",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+    }
+    # No errors collected
+    assert data["errors"] == {}
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_zephyr_keys_only(monkeypatch):
+    """Fetching only Zephyr keys should return successfully,
+    and without errors."""
+
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-T123_a"
+
+    # Dummy response for get_test_cases (Zephyr)
+    async def dummy_get_test_cases(keys, zephyr=None):
+        return {k: f"Description of {k}" for k in keys}
+
+    # Patch Zephyr service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        dummy_get_test_cases,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Zephyr keys returned successfully
+    assert data["data"] == {
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Description of BLOCK-T123",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+        "BLOCK-T123_a": {
+            "key": "BLOCK-T123_a",
+            "summary": "Description of BLOCK-T123_a",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+    }
+    # No errors collected from lack of Jira keys
+    assert data["errors"] == {}
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_jira_keys_only(monkeypatch):
+    """Fetching only Jira keys should return successfully,
+    and without errors."""
+
+    endpoint = "/block-details?key=BLOCK-456&key=BLOCK-789"
+
+    # Dummy response for get_test_cases (Zephyr)
+    def dummy_get_block_ticket_summaries(keys):
+        return {k: f"Description of {k}" for k in keys}
+
+    # Patch Zephyr service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        dummy_get_block_ticket_summaries,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Jira keys returned successfully
+    assert data["data"] == {
+        "BLOCK-456": {
+            "key": "BLOCK-456",
+            "summary": "Description of BLOCK-456",
+            "url": f"{JIRA_BLOCK_BASE_URL}BLOCK-456",
+            "source": "jira",
+        },
+        "BLOCK-789": {
+            "key": "BLOCK-789",
+            "summary": "Description of BLOCK-789",
+            "url": f"{JIRA_BLOCK_BASE_URL}BLOCK-789",
+            "source": "jira",
+        },
+    }
+    # No errors collected from lack of Zephyr keys
+    assert data["errors"] == {}
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
     """Simulate exception in get_test_cases → HTTP 500"""
 
-    endpoint = "/test-cases?key=BLOCK-T123"
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
-    async def raise_error(keys, zephyr=None):
+    # Zephyr failure
+    async def raise_zephyr_error(keys, zephyr=None):
         raise Exception("Zephyr API failure")
 
     monkeypatch.setattr(
         "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
-        raise_error,
+        raise_zephyr_error,
+    )
+
+    # Jira success
+    def dummy_get_block_ticket_summaries(keys):
+        return {k: f"Description of {k}" for k in keys}
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        dummy_get_block_ticket_summaries,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Jira key returned successfully
+    assert data["data"] == {
+        "BLOCK-456": {
+            "key": "BLOCK-456",
+            "summary": "Description of BLOCK-456",
+            "url": f"{JIRA_BLOCK_BASE_URL}BLOCK-456",
+            "source": "jira",
+        }
+    }
+    # Check expected error has been collected
+    assert "zephyr" in data["errors"]
+    assert data["errors"]["zephyr"] == "Zephyr API failure"
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_jira_service_failure(monkeypatch):
+    """Simulate exception in get_block_ticket_summaries → HTTP 500"""
+
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
+
+    # Jira failure
+    def raise_jira_error(keys):
+        raise Exception("Jira API failure")
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        raise_jira_error,
+    )
+
+    # Zephyr success
+    async def dummy_get_test_cases(keys, zephyr=None):
+        return {k: f"Description of {k}" for k in keys}
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        dummy_get_test_cases,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Zephyr key returned successfully
+    assert data["data"] == {
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Description of BLOCK-T123",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+    }
+    # Check expected error collected
+    assert "jira" in data["errors"]
+    assert data["errors"]["jira"] == "Jira API failure"
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_block_details_endpoint_both_services_failure(monkeypatch):
+    """Simulate exceptions in get_test_cases → HTTP 500 and
+    get_block_ticket_summaries → HTTP 500.
+    """
+
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
+
+    async def raise_zephyr_error(keys, zephyr=None):
+        raise Exception("Zephyr API failure")
+
+    def raise_jira_error(keys):
+        raise Exception("Jira API failure")
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        raise_zephyr_error,
+    )
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        raise_jira_error,
     )
 
     app.dependency_overrides[get_access_token] = lambda: "dummy-token"
 
     response = client.get(endpoint)
     assert response.status_code == 500
-    assert response.json()["detail"] == "Zephyr API failure"
+    assert response.json()["detail"] == "Both Zephyr and Jira requests failed."
 
     app.dependency_overrides.pop(get_access_token, None)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -13,10 +13,9 @@ from lsst.ts.logging_and_reporting import __version__
 from lsst.ts.logging_and_reporting.utils import (
     JIRA_BLOCK_BASE_URL,
     ZEPHYR_BLOCK_BASE_URL,
-    get_access_token,
     get_jira_hostname,
 )
-from lsst.ts.logging_and_reporting.web_app.main import app, jira_auth, rsp_auth
+from lsst.ts.logging_and_reporting.web_app.main import app, jira_auth, rsp_auth, zephyr_auth
 
 client = TestClient(app)
 
@@ -1269,11 +1268,11 @@ def test_block_details_endpoint_success(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
     # Dummy response for get_test_cases (Zephyr)
-    async def dummy_get_test_cases(keys, zephyr=None):
+    async def dummy_get_test_cases(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Dummy response for get_block_ticket_summaries (Jira)
-    def dummy_get_block_ticket_summaries(keys):
+    def dummy_get_block_ticket_summaries(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Patch Zephyr service
@@ -1288,8 +1287,10 @@ def test_block_details_endpoint_success(monkeypatch):
         dummy_get_block_ticket_summaries,
     )
 
-    # Override auth token
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     # Make request
     response = client.get(endpoint)
@@ -1317,7 +1318,9 @@ def test_block_details_endpoint_success(monkeypatch):
     assert data["errors"] == {}
 
     # Clean up
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_mixed_invalid_keys(monkeypatch):
@@ -1326,7 +1329,7 @@ def test_block_details_endpoint_mixed_invalid_keys(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=INVALID-1"
 
     # Dummy response for get_test_cases (Zephyr)
-    async def dummy_get_test_cases(keys, zephyr=None):
+    async def dummy_get_test_cases(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Patch Zephyr service
@@ -1335,7 +1338,10 @@ def test_block_details_endpoint_mixed_invalid_keys(monkeypatch):
         dummy_get_test_cases,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1348,15 +1354,21 @@ def test_block_details_endpoint_mixed_invalid_keys(monkeypatch):
     # No errors collected
     assert data["errors"] == {}
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_all_invalid_keys(monkeypatch):
-    """No invalid keys should return an empty dict."""
+    """All invalid keys should return an empty dict."""
 
     endpoint = "/block-details?key=unknown&key=INVALID-1"
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1369,7 +1381,10 @@ def test_block_details_endpoint_all_invalid_keys(monkeypatch):
     # No errors collected
     assert data["errors"] == {}
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_duplicate_keys(monkeypatch):
@@ -1378,7 +1393,7 @@ def test_block_details_endpoint_duplicate_keys(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-T123"
 
     # Dummy response for get_test_cases (Zephyr)
-    async def dummy_get_test_cases(keys, zephyr=None):
+    async def dummy_get_test_cases(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Patch Zephyr service
@@ -1387,7 +1402,10 @@ def test_block_details_endpoint_duplicate_keys(monkeypatch):
         dummy_get_test_cases,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1406,7 +1424,10 @@ def test_block_details_endpoint_duplicate_keys(monkeypatch):
     # No errors collected
     assert data["errors"] == {}
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_zephyr_keys_only(monkeypatch):
@@ -1416,7 +1437,7 @@ def test_block_details_endpoint_zephyr_keys_only(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-T123_a"
 
     # Dummy response for get_test_cases (Zephyr)
-    async def dummy_get_test_cases(keys, zephyr=None):
+    async def dummy_get_test_cases(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Patch Zephyr service
@@ -1425,7 +1446,10 @@ def test_block_details_endpoint_zephyr_keys_only(monkeypatch):
         dummy_get_test_cases,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1450,7 +1474,10 @@ def test_block_details_endpoint_zephyr_keys_only(monkeypatch):
     # No errors collected from lack of Jira keys
     assert data["errors"] == {}
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_jira_keys_only(monkeypatch):
@@ -1460,7 +1487,7 @@ def test_block_details_endpoint_jira_keys_only(monkeypatch):
     endpoint = "/block-details?key=BLOCK-456&key=BLOCK-789"
 
     # Dummy response for get_test_cases (Zephyr)
-    def dummy_get_block_ticket_summaries(keys):
+    def dummy_get_block_ticket_summaries(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     # Patch Zephyr service
@@ -1469,7 +1496,10 @@ def test_block_details_endpoint_jira_keys_only(monkeypatch):
         dummy_get_block_ticket_summaries,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1494,7 +1524,10 @@ def test_block_details_endpoint_jira_keys_only(monkeypatch):
     # No errors collected from lack of Zephyr keys
     assert data["errors"] == {}
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
@@ -1503,7 +1536,7 @@ def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
     # Zephyr failure
-    async def raise_zephyr_error(keys, zephyr=None):
+    async def raise_zephyr_error(keys, **kwargs):
         raise Exception("Zephyr API failure")
 
     monkeypatch.setattr(
@@ -1512,7 +1545,7 @@ def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
     )
 
     # Jira success
-    def dummy_get_block_ticket_summaries(keys):
+    def dummy_get_block_ticket_summaries(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     monkeypatch.setattr(
@@ -1520,7 +1553,10 @@ def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
         dummy_get_block_ticket_summaries,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1541,7 +1577,10 @@ def test_block_details_endpoint_zephyr_service_failure(monkeypatch):
     assert "zephyr" in data["errors"]
     assert data["errors"]["zephyr"] == "Zephyr API failure"
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_jira_service_failure(monkeypatch):
@@ -1550,7 +1589,7 @@ def test_block_details_endpoint_jira_service_failure(monkeypatch):
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
     # Jira failure
-    def raise_jira_error(keys):
+    def raise_jira_error(keys, **kwargs):
         raise Exception("Jira API failure")
 
     monkeypatch.setattr(
@@ -1559,7 +1598,7 @@ def test_block_details_endpoint_jira_service_failure(monkeypatch):
     )
 
     # Zephyr success
-    async def dummy_get_test_cases(keys, zephyr=None):
+    async def dummy_get_test_cases(keys, **kwargs):
         return {k: f"Description of {k}" for k in keys}
 
     monkeypatch.setattr(
@@ -1567,7 +1606,10 @@ def test_block_details_endpoint_jira_service_failure(monkeypatch):
         dummy_get_test_cases,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 200
@@ -1588,7 +1630,10 @@ def test_block_details_endpoint_jira_service_failure(monkeypatch):
     assert "jira" in data["errors"]
     assert data["errors"]["jira"] == "Jira API failure"
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_block_details_endpoint_both_services_failure(monkeypatch):
@@ -1598,10 +1643,10 @@ def test_block_details_endpoint_both_services_failure(monkeypatch):
 
     endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
 
-    async def raise_zephyr_error(keys, zephyr=None):
+    async def raise_zephyr_error(keys, **kwargs):
         raise Exception("Zephyr API failure")
 
-    def raise_jira_error(keys):
+    def raise_jira_error(keys, **kwargs):
         raise Exception("Jira API failure")
 
     monkeypatch.setattr(
@@ -1614,10 +1659,91 @@ def test_block_details_endpoint_both_services_failure(monkeypatch):
         raise_jira_error,
     )
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    # Override auth tokens and host
+    app.dependency_overrides[zephyr_auth] = lambda: "dummy-zephyr-token"
+    app.dependency_overrides[jira_auth] = lambda: "dummy-jira-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
 
     response = client.get(endpoint)
     assert response.status_code == 500
     assert response.json()["detail"] == "Both Zephyr and Jira requests failed."
 
-    app.dependency_overrides.pop(get_access_token, None)
+    # Clean up
+    app.dependency_overrides.pop(zephyr_auth, None)
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
+
+
+def test_block_details_integration_success(monkeypatch):
+    """End-to-end success case with real dependency injection and
+    environment-based authentication.
+    """
+    monkeypatch.setenv("ZEPHYR_API_TOKEN", "zephyr-token")
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.setenv("JIRA_API_HOSTNAME", "mock-host")
+
+    response = client.get("/block-details?key=BLOCK-123")
+
+    assert response.status_code == 200
+
+
+def test_block_details_integration_auth_failure(monkeypatch):
+    """End-to-end request fails with 401 when required
+    authentication credentials are missing.
+    """
+
+    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+    monkeypatch.delenv("ZEPHYR_API_TOKEN", raising=False)
+
+    response = client.get("/block-details?key=BLOCK-123")
+
+    assert response.status_code == 401
+
+
+def test_block_details_integration_jira_failure(monkeypatch):
+    """End-to-end partial failure where Jira service error is
+    captured while Zephyr succeeds.
+    """
+    endpoint = "/block-details?key=BLOCK-T123&key=BLOCK-456"
+
+    # Use real dependency system
+    monkeypatch.setenv("ZEPHYR_API_TOKEN", "zephyr-token")
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.setenv("JIRA_API_HOSTNAME", "mock-host")
+
+    # Jira failure
+    def mock_get_block_ticket_summaries(keys, jira_token=None, jira_hostname=None):
+        raise Exception("Jira service down")
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_block_ticket_summaries",
+        mock_get_block_ticket_summaries,
+    )
+
+    # Zephyr success
+    async def mock_get_test_cases(keys, **kwargs):
+        return {k: f"Description of {k}" for k in keys}
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        mock_get_test_cases,
+    )
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "data" in data
+    assert "errors" in data
+    # Zephyr key returned successfully
+    assert data["data"] == {
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Description of BLOCK-T123",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+            "source": "zephyr",
+        },
+    }
+    # Check expected error collected
+    assert "jira" in data["errors"]
+    assert data["errors"]["jira"] == "Jira service down"

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1258,3 +1258,82 @@ def test_expected_exposures_endpoint_passes_correct_params(monkeypatch):
 
     assert response.status_code == 200
     assert called == {"start": 20240101, "end": 20240102}
+
+
+def test_test_cases_endpoint_success(monkeypatch):
+    endpoint = "/test-cases?key=BLOCK-T123&key=BLOCK-T456"
+
+    # Dummy response for get_test_cases
+    async def dummy_get_test_cases(keys, zephyr=None):
+        return {k: f"Name for {k}" for k in keys}
+
+    # Patch service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        dummy_get_test_cases,
+    )
+
+    # Override auth token
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    # Make request
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "data" in data
+    assert data["data"] == {
+        "BLOCK-T123": "Name for BLOCK-T123",
+        "BLOCK-T456": "Name for BLOCK-T456",
+    }
+
+    # Clean up
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_test_cases_endpoint_invalid_keys(monkeypatch):
+    """Invalid keys should be filtered out."""
+
+    endpoint = "/test-cases?key=BLOCK-T123&key=INVALID-1"
+
+    async def dummy_get_test_cases(keys, zephyr=None):
+        # Valid keys only
+        return {"BLOCK-T123": "Name for BLOCK-T123"}
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        dummy_get_test_cases,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 200
+    data = response.json()
+    # Only valid key returned
+    assert "BLOCK-T123" in data["data"]
+    assert "INVALID-1" not in data["data"]
+
+    app.dependency_overrides.pop(get_access_token, None)
+
+
+def test_test_cases_endpoint_service_failure(monkeypatch):
+    """Simulate exception in get_test_cases → HTTP 500"""
+
+    endpoint = "/test-cases?key=BLOCK-T123"
+
+    async def raise_error(keys, zephyr=None):
+        raise Exception("Zephyr API failure")
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_test_cases",
+        raise_error,
+    )
+
+    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+
+    response = client.get(endpoint)
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Zephyr API failure"
+
+    app.dependency_overrides.pop(get_access_token, None)

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -10,6 +10,7 @@ from lsst.ts.logging_and_reporting.jira import (
     OBS_SYSTEMS_FIELD,
     TIME_LOST_FIELD,
     JiraAdapter,
+    JiraClient,
     ex,
     get_system_names,
 )
@@ -291,3 +292,48 @@ def test_get_obs_issues_is_new_boundaries(
 
     assert result[3]["key"] == "OBS-BEFORE"
     assert result[3]["isNew"] is False  # before start -> False
+
+
+# ------------------------
+# Tests for fetch_block_ticket_summaries
+# ------------------------
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_fetch_block_ticket_summaries_success(mock_get):
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "issues": [
+            {"key": "BLOCK-1", "fields": {"summary": "First ticket"}},
+            {"key": "BLOCK-2", "fields": {"summary": "Second ticket"}},
+        ]
+    }
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    client = JiraClient()
+    result = client.fetch_block_ticket_summaries(["BLOCK-1", "BLOCK-2"])
+
+    assert result == {
+        "BLOCK-1": "First ticket",
+        "BLOCK-2": "Second ticket",
+    }
+
+
+def test_fetch_block_ticket_summaries_empty_input():
+    client = JiraClient()
+    result = client.fetch_block_ticket_summaries([])
+
+    assert result == {}
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_search_http_error(mock_get):
+    mock_response = Mock()
+    mock_response.raise_for_status.side_effect = Exception("HTTP error")
+    mock_response.status_code = 500
+    mock_response.text = "Internal error"
+    mock_get.return_value = mock_response
+
+    client = JiraClient()
+
+    with pytest.raises(Exception):  # optionally ex.BaseLogrepError if imported
+        client._search("some jql", "summary")

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -10,7 +10,6 @@ from lsst.ts.logging_and_reporting.jira import (
     OBS_SYSTEMS_FIELD,
     TIME_LOST_FIELD,
     JiraAdapter,
-    JiraClient,
     ex,
     get_system_names,
 )
@@ -309,8 +308,8 @@ def test_fetch_block_ticket_summaries_success(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    client = JiraClient()
-    result = client.fetch_block_ticket_summaries(["BLOCK-1", "BLOCK-2"])
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    result = adapter.fetch_block_ticket_summaries(["BLOCK-1", "BLOCK-2"])
 
     assert result == {
         "BLOCK-1": "First ticket",
@@ -319,21 +318,7 @@ def test_fetch_block_ticket_summaries_success(mock_get):
 
 
 def test_fetch_block_ticket_summaries_empty_input():
-    client = JiraClient()
-    result = client.fetch_block_ticket_summaries([])
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    result = adapter.fetch_block_ticket_summaries([])
 
     assert result == {}
-
-
-@patch("lsst.ts.logging_and_reporting.jira.requests.get")
-def test_search_http_error(mock_get):
-    mock_response = Mock()
-    mock_response.raise_for_status.side_effect = Exception("HTTP error")
-    mock_response.status_code = 500
-    mock_response.text = "Internal error"
-    mock_get.return_value = mock_response
-
-    client = JiraClient()
-
-    with pytest.raises(Exception):  # optionally ex.BaseLogrepError if imported
-        client._search("some jql", "summary")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -442,13 +442,16 @@ class TestGetBlockTicketSummaries:
         provided.
         """
 
-        class DummyJiraClient:
+        class DummyJiraAdapter:
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
+
             def fetch_block_ticket_summaries(self, ticket_keys):
                 return {"SHOULD": "NOT BE CALLED"}
 
         monkeypatch.setattr(
-            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
-            DummyJiraClient,
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraAdapter",
+            DummyJiraAdapter,
         )
 
         result = jira_service.get_block_ticket_summaries([])
@@ -459,13 +462,16 @@ class TestGetBlockTicketSummaries:
         fetch_block_ticket_summaries returns an empty dict.
         """
 
-        class DummyJiraClient:
+        class DummyJiraAdapter:
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
+
             def fetch_block_ticket_summaries(self, ticket_keys):
                 return {}
 
         monkeypatch.setattr(
-            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
-            DummyJiraClient,
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraAdapter",
+            DummyJiraAdapter,
         )
 
         result = jira_service.get_block_ticket_summaries(["BLOCK-1"])
@@ -474,13 +480,16 @@ class TestGetBlockTicketSummaries:
     def test_returns_ticket_summaries_correctly(self, monkeypatch):
         """Test that the function returns the expected ticket summaries."""
 
-        class DummyJiraClient:
+        class DummyJiraAdapter:
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
+
             def fetch_block_ticket_summaries(self, ticket_keys):
                 return {key: f"Summary for {key}" for key in ticket_keys}
 
         monkeypatch.setattr(
-            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
-            DummyJiraClient,
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraAdapter",
+            DummyJiraAdapter,
         )
 
         ticket_keys = ["BLOCK-1", "BLOCK-2"]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -381,26 +381,6 @@ async def test_get_test_cases_returns_names():
 
 
 @pytest.mark.asyncio
-async def test_get_test_cases_filters_invalid_keys():
-    """Invalid keys should be ignored."""
-
-    class DummyZephyr:
-        async def get_test_case(self, key):
-            return {"name": "Should not matter"}
-
-    keys = ["BLOCK-T123", "INVALID-1", "BLOCK-XYZ"]
-
-    result = await zephyr_service.get_test_cases(
-        keys,
-        zephyr=DummyZephyr(),
-    )
-
-    assert result == {
-        "BLOCK-T123": "Should not matter",
-    }
-
-
-@pytest.mark.asyncio
 async def test_get_test_cases_uses_parent_key_for_suffix():
     """Keys with suffix should query parent but return original key."""
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,6 +7,7 @@ from lsst.ts.logging_and_reporting.web_app.services import (
     consdb_service,
     jira_service,
     scheduler_service,
+    zephyr_service,
 )
 
 
@@ -356,3 +357,98 @@ class TestGetJiraTickets:
             )
 
             assert not match
+
+
+@pytest.mark.asyncio
+async def test_get_test_cases_returns_names():
+    """Valid keys should return mapping of key -> test case name."""
+
+    class DummyZephyr:
+        async def get_test_case(self, key):
+            return {"name": f"Name for {key}"}
+
+    keys = ["BLOCK-T123", "BLOCK-T456"]
+
+    result = await zephyr_service.get_test_cases(
+        keys,
+        zephyr=DummyZephyr(),
+    )
+
+    assert result == {
+        "BLOCK-T123": "Name for BLOCK-T123",
+        "BLOCK-T456": "Name for BLOCK-T456",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_test_cases_filters_invalid_keys():
+    """Invalid keys should be ignored."""
+
+    class DummyZephyr:
+        async def get_test_case(self, key):
+            return {"name": "Should not matter"}
+
+    keys = ["BLOCK-T123", "INVALID-1", "BLOCK-XYZ"]
+
+    result = await zephyr_service.get_test_cases(
+        keys,
+        zephyr=DummyZephyr(),
+    )
+
+    assert result == {
+        "BLOCK-T123": "Should not matter",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_test_cases_uses_parent_key_for_suffix():
+    """Keys with suffix should query parent but return original key."""
+
+    called_with = []
+
+    class DummyZephyr:
+        async def get_test_case(self, key):
+            called_with.append(key)
+            return {"name": "Parent name"}
+
+    keys = ["BLOCK-T123_a"]
+
+    result = await zephyr_service.get_test_cases(
+        keys,
+        zephyr=DummyZephyr(),
+    )
+
+    assert called_with == ["BLOCK-T123"]
+    assert result == {"BLOCK-T123_a": "Parent name"}
+
+
+@pytest.mark.asyncio
+async def test_get_test_cases_skips_failed_retrieval():
+    """If Zephyr raises for a key, it should be skipped."""
+
+    class DummyZephyr:
+        async def get_test_case(self, key):
+            if key == "BLOCK-T123":
+                raise Exception("fail")
+            return {"name": "OK"}
+
+    keys = ["BLOCK-T123", "BLOCK-T456"]
+
+    result = await zephyr_service.get_test_cases(
+        keys,
+        zephyr=DummyZephyr(),
+    )
+
+    assert result == {"BLOCK-T456": "OK"}
+
+
+@pytest.mark.asyncio
+async def test_get_test_cases_empty_input():
+    """Empty key list should return empty dict."""
+
+    result = await zephyr_service.get_test_cases(
+        [],
+        zephyr=object(),  # not used
+    )
+
+    assert result == {}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -432,3 +432,63 @@ async def test_get_test_cases_empty_input():
     )
 
     assert result == {}
+
+
+class TestGetBlockTicketSummaries:
+    """Tests for the get_block_ticket_summaries function."""
+
+    def test_returns_empty_dict_when_no_ticket_keys(self, monkeypatch):
+        """Test that an empty dict is returned when no ticket keys are
+        provided.
+        """
+
+        class DummyJiraClient:
+            def fetch_block_ticket_summaries(self, ticket_keys):
+                return {"SHOULD": "NOT BE CALLED"}
+
+        monkeypatch.setattr(
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
+            DummyJiraClient,
+        )
+
+        result = jira_service.get_block_ticket_summaries([])
+        assert result == {}
+
+    def test_returns_empty_dict_when_fetch_returns_none(self, monkeypatch):
+        """Test that an empty dict is returned when
+        fetch_block_ticket_summaries returns an empty dict.
+        """
+
+        class DummyJiraClient:
+            def fetch_block_ticket_summaries(self, ticket_keys):
+                return {}
+
+        monkeypatch.setattr(
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
+            DummyJiraClient,
+        )
+
+        result = jira_service.get_block_ticket_summaries(["BLOCK-1"])
+        assert result == {}
+
+    def test_returns_ticket_summaries_correctly(self, monkeypatch):
+        """Test that the function returns the expected ticket summaries."""
+
+        class DummyJiraClient:
+            def fetch_block_ticket_summaries(self, ticket_keys):
+                return {key: f"Summary for {key}" for key in ticket_keys}
+
+        monkeypatch.setattr(
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraClient",
+            DummyJiraClient,
+        )
+
+        ticket_keys = ["BLOCK-1", "BLOCK-2"]
+        result = jira_service.get_block_ticket_summaries(ticket_keys)
+
+        expected = {
+            "BLOCK-1": "Summary for BLOCK-1",
+            "BLOCK-2": "Summary for BLOCK-2",
+        }
+
+        assert result == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,13 +10,13 @@ from lsst.ts.logging_and_reporting.utils import (
     AUTH_SOURCES,
     JIRA_BLOCK_BASE_URL,
     ZEPHYR_BLOCK_BASE_URL,
+    build_block_response,
     get_access_token,
     get_auth_header,
     get_jira_hostname,
     make_json_safe,
     retrieve_access_token,
     stringify_special_floats,
-    build_block_response,
 )
 
 app = FastAPI()
@@ -119,6 +119,30 @@ def test_retrieve_access_token_lsst_utils():
         assert token == "lsst-token"
 
 
+# Fetch default (RSP) token via env var
+def test_get_access_token_default_env_variable(monkeypatch):
+    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
+    dependency = get_access_token()
+    token = dependency()
+    assert token == "env_token"
+
+
+# Fetch Jira token via env var
+def test_get_access_token_jira_env_variable(monkeypatch):
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    dependency = get_access_token("jira")
+    token = dependency()
+    assert token == "jira-token"
+
+
+# Fetch Zephyr token via env var
+def test_get_access_token_zephyr_env_variable(monkeypatch):
+    monkeypatch.setenv("ZEPHYR_API_TOKEN", "zephyr-token")
+    dependency = get_access_token("zephyr")
+    token = dependency()
+    assert token == "zephyr-token"
+
+
 @app.get("/test-default-access-token")
 def access_token_endpoint(
     request: Request = None,
@@ -135,20 +159,12 @@ def jira_access_token_endpoint(
     return {"token": auth_token}
 
 
-# Fetch default (RSP) token via env var
-def test_get_access_token_default_env_variable(monkeypatch):
-    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
-    dependency = get_access_token()
-    token = dependency()
-    assert token == "env_token"
-
-
-# Fetch Jira token via env var
-def test_get_access_token_jira_env_variable(monkeypatch):
-    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
-    dependency = get_access_token("jira")
-    token = dependency()
-    assert token == "jira-token"
+@app.get("/test-zephyr-access-token")
+def zephyr_access_token_endpoint(
+    request: Request = None,
+    auth_token: str = Depends(get_access_token("zephyr")),
+):
+    return {"token": auth_token}
 
 
 def test_get_access_token_request_headers(monkeypatch):
@@ -173,6 +189,14 @@ def test_get_access_token_no_jira_token(monkeypatch):
     response = client.get("/test-jira-access-token")
     assert response.status_code == 401
     assert response.json() == {"detail": "Jira authentication token could not be retrieved by any method."}
+
+
+def test_get_access_token_no_zephyr_token(monkeypatch):
+    monkeypatch.delenv("ZEPHYR_API_TOKEN", raising=False)
+    client = TestClient(app)
+    response = client.get("/test-zephyr-access-token")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Zephyr authentication token could not be retrieved by any method."}
 
 
 def test_get_auth_header_valid():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,12 +8,15 @@ from fastapi.testclient import TestClient
 
 from lsst.ts.logging_and_reporting.utils import (
     AUTH_SOURCES,
+    JIRA_BLOCK_BASE_URL,
+    ZEPHYR_BLOCK_BASE_URL,
     get_access_token,
     get_auth_header,
     get_jira_hostname,
     make_json_safe,
     retrieve_access_token,
     stringify_special_floats,
+    build_block_response,
 )
 
 app = FastAPI()
@@ -329,3 +332,68 @@ def test_make_json_safe_json_serializable():
     result = make_json_safe(obj)
     json_str = json.dumps(result)  # Should not raise
     assert json_str is not None
+
+
+# Test the constructor that unifies responses from Jira and Zephyr
+# for BLOCK details.
+def test_build_block_response_combines_sources():
+    zephyr_data = {
+        "BLOCK-T123": "Zephyr summary",
+    }
+    jira_data = {
+        "BLOCK-456": "Jira summary",
+    }
+
+    result = build_block_response(zephyr_data, jira_data)
+
+    assert result == {
+        "BLOCK-T123": {
+            "key": "BLOCK-T123",
+            "summary": "Zephyr summary",
+            "source": "zephyr",
+            "url": f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123",
+        },
+        "BLOCK-456": {
+            "key": "BLOCK-456",
+            "summary": "Jira summary",
+            "source": "jira",
+            "url": f"{JIRA_BLOCK_BASE_URL}BLOCK-456",
+        },
+    }
+
+
+def test_build_block_response_zephyr_suffix_stripped():
+    zephyr_data = {
+        "BLOCK-T123_a": "Zephyr summary",
+    }
+
+    result = build_block_response(zephyr_data, {})
+
+    assert result["BLOCK-T123_a"]["url"] == f"{ZEPHYR_BLOCK_BASE_URL}BLOCK-T123"
+
+
+def test_build_block_response_empty_inputs():
+    result = build_block_response({}, {})
+    assert result == {}
+
+
+def test_build_block_response_zephyr_only():
+    zephyr_data = {
+        "BLOCK-T123": "Zephyr summary",
+    }
+
+    result = build_block_response(zephyr_data, {})
+
+    assert "BLOCK-T123" in result
+    assert result["BLOCK-T123"]["source"] == "zephyr"
+
+
+def test_build_block_response_jira_only():
+    jira_data = {
+        "BLOCK-456": "Jira summary",
+    }
+
+    result = build_block_response({}, jira_data)
+
+    assert "BLOCK-456" in result
+    assert result["BLOCK-456"]["source"] == "jira"


### PR DESCRIPTION
This PR introduces a service and endpoint for fetching Zephyr/Jira BLOCK details.

**Note:** new PR [OSW-2058](https://github.com/lsst-ts/ts_logging_and_reporting/pull/117) has refactored `JiraAdapter` to not force `dayobs` and `get_access_token` is now accepting multiple token kinds. This PR should be merged after OSW-2058.

[OSW-2058]: https://rubinobs.atlassian.net/browse/OSW-2058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ