### PR TITLE
OSW-1257: Enable fetching all tracebacks from rubin-nights

### DIFF
--- a/doc/news/OSW-1257.misc.rst
+++ b/doc/news/OSW-1257.misc.rst
@@ -1,0 +1,1 @@
+Enable fetching all tracebacks from rubin-nights for the Context Feed.

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -191,7 +191,7 @@ def get_context_feed(
         ) + TimeDelta(1, format="jd")
 
         # Returns pandas dataframe and list
-        df, cols = get_consolidated_messages(t_start, t_end, endpoints)
+        df, cols = get_consolidated_messages(t_start, t_end, endpoints, all_tracebacks=True)
 
         # Discard all columns that are not listed in cols
         df_cols_only = df[df.columns.intersection(cols)]


### PR DESCRIPTION
This PR makes use of the new `all_tracebacks` flag when fetching Context Feed data from `rubin-nights`.

**Note**: there is a bug with this flag that is fixed with `rubin-nights v0.12.0`.