### PR TITLE
OSW-1945: Redirect consdb access to use usdf-rsp-int when we are on usdf-rsp-dev

### DIFF
--- a/doc/news/OSW-1945.feature.rst
+++ b/doc/news/OSW-1945.feature.rst
@@ -1,0 +1,1 @@
+Allow ConsDB at usdf-rsp-int to be queried when we are using usdf-rsp-dev as our EXTERNAL_INSTANCE_URL

--- a/python/lsst/ts/logging_and_reporting/consdb.py
+++ b/python/lsst/ts/logging_and_reporting/consdb.py
@@ -1,6 +1,5 @@
 # Used efd.py as a starting point.  Layered in consolidated_database.py
 
-import logging
 import traceback
 import warnings
 from collections import defaultdict
@@ -19,8 +18,6 @@ from lsst.ts.logging_and_reporting.source_adapters import SourceAdapter
 #   -d '{
 #   "query": "SELECT * FROM cdb_lsstcomcam.exposure LIMIT 2"
 # }'
-
-logger = logging.getLogger(__name__)
 
 
 class ConsdbAdapter(SourceAdapter):
@@ -53,7 +50,6 @@ class ConsdbAdapter(SourceAdapter):
         if server_url == ut.Server.usdfdev:
             # ConsDB's usdf-rsp-dev data is unstable, use int for integration
             server_url = ut.Server.usdfint
-        logger.info(f"ConsDB Adapter Server URL {server_url}")
 
         super().__init__(
             server_url=server_url,
@@ -64,7 +60,6 @@ class ConsdbAdapter(SourceAdapter):
             warning=warning,
             auth_token=auth_token,
         )
-        logger.info(f"ConsDB Adapter SELF Server URL {self.server}")
 
         self.status = dict()
         self.exposures = dict()  # dd[instrument] = [rec, ...]

--- a/python/lsst/ts/logging_and_reporting/consdb.py
+++ b/python/lsst/ts/logging_and_reporting/consdb.py
@@ -19,6 +19,8 @@ from lsst.ts.logging_and_reporting.source_adapters import SourceAdapter
 #   "query": "SELECT * FROM cdb_lsstcomcam.exposure LIMIT 2"
 # }'
 
+import logging
+logger = logging.getLogger(__name__)
 
 class ConsdbAdapter(SourceAdapter):
     abbrev = "CDB"
@@ -47,6 +49,11 @@ class ConsdbAdapter(SourceAdapter):
         warning=True,
         auth_token=None,
     ):
+        if server_url == ut.Server.usdfdev:
+            # ConsDB's usdf-rsp-dev data is unstable, use int for integration
+            server_url = ut.Server.usdfint
+        logger.info(f"ConsDB Adapter Server URL {server_url}")
+
         super().__init__(
             server_url=server_url,
             max_dayobs=max_dayobs,
@@ -56,6 +63,7 @@ class ConsdbAdapter(SourceAdapter):
             warning=warning,
             auth_token=auth_token,
         )
+        logger.info(f"ConsDB Adapter SELF Server URL {self.server}")
 
         self.status = dict()
         self.exposures = dict()  # dd[instrument] = [rec, ...]

--- a/python/lsst/ts/logging_and_reporting/consdb.py
+++ b/python/lsst/ts/logging_and_reporting/consdb.py
@@ -1,5 +1,6 @@
 # Used efd.py as a starting point.  Layered in consolidated_database.py
 
+import logging
 import traceback
 import warnings
 from collections import defaultdict
@@ -19,8 +20,8 @@ from lsst.ts.logging_and_reporting.source_adapters import SourceAdapter
 #   "query": "SELECT * FROM cdb_lsstcomcam.exposure LIMIT 2"
 # }'
 
-import logging
 logger = logging.getLogger(__name__)
+
 
 class ConsdbAdapter(SourceAdapter):
     abbrev = "CDB"

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -23,7 +23,6 @@
 import copy
 import datetime as dt
 import itertools
-import logging
 import traceback
 import warnings
 from abc import ABC
@@ -33,8 +32,6 @@ import requests
 
 import lsst.ts.logging_and_reporting.exceptions as ex
 import lsst.ts.logging_and_reporting.utils as ut
-
-logger = logging.getLogger(__name__)
 
 MAX_CONNECT_TIMEOUT = 7.05  # seconds
 MAX_READ_TIMEOUT = 180  # seconds
@@ -71,11 +68,6 @@ class SourceAdapter(ABC):
         range large or you will use lots of memory. Tens of days is probably
         ok.
         """
-        if not server_url:
-            logging.warning(
-                f"""\n{self.__class__.__name__}\'s Server URL not set at
-                Source Adapter level, using {ut.Server.get_url()}\n"""
-            )
 
         self.server = server_url or ut.Server.get_url()
         self.verbose = verbose

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -23,6 +23,7 @@
 import copy
 import datetime as dt
 import itertools
+import logging
 import traceback
 import warnings
 from abc import ABC
@@ -32,6 +33,8 @@ import requests
 
 import lsst.ts.logging_and_reporting.exceptions as ex
 import lsst.ts.logging_and_reporting.utils as ut
+
+logger = logging.getLogger(__name__)
 
 MAX_CONNECT_TIMEOUT = 7.05  # seconds
 MAX_READ_TIMEOUT = 180  # seconds
@@ -68,6 +71,11 @@ class SourceAdapter(ABC):
         range large or you will use lots of memory. Tens of days is probably
         ok.
         """
+        if not server_url:
+            logging.warning(
+                f"""\n{self.__class__.__name__}\'s Server URL not set at
+                Source Adapter level, using {ut.Server.get_url()}\n"""
+            )
 
         self.server = server_url or ut.Server.get_url()
         self.verbose = verbose

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -312,8 +312,6 @@ def get_access_token(request: Request = None):
         import lsst.rsp.utils
 
         return lsst.rsp.utils.get_info()
-        # TODO: OSW-2050 Do we intend to keep supporting use of nd
-        # in personal notebooks in RSP ?
     except ImportError:
         env_token = os.getenv("ACCESS_TOKEN")
         if env_token is not None:

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -245,11 +245,12 @@ class Timer:
 class Server:
     """Do I need a class for this instead of just using line 262?"""
 
-    summit = "https://summit-lsp.lsst.codes"
-    usdfdev = "https://usdf-rsp-dev.slac.stanford.edu"
-    usdf = "https://usdf-rsp.slac.stanford.edu"
-    tucson = "https://tucson-teststand.lsst.codes"
     base = "https://base-lsp.lsst.codes"
+    summit = "https://summit-lsp.lsst.codes"
+    tucson = "https://tucson-teststand.lsst.codes"
+    usdf = "https://usdf-rsp.slac.stanford.edu"
+    usdfdev = "https://usdf-rsp-dev.slac.stanford.edu"
+    usdfint = "https://usdf-rsp-int.slac.stanford.edu"
 
     @classmethod
     def get_all(cls):
@@ -263,16 +264,18 @@ class Server:
         current = os.environ.get(env_var_name)
 
         match current:
-            case Server.summit:
-                return Server.summit
-            case Server.usdfdev:
-                return Server.usdfdev
-            case Server.usdf:
-                return Server.usdf
-            case Server.tucson:
-                return Server.tucson
             case Server.base:
                 return Server.base
+            case Server.summit:
+                return Server.summit
+            case Server.tucson:
+                return Server.tucson
+            case Server.usdf:
+                return Server.usdf
+            case Server.usdfdev:
+                return Server.usdfdev
+            case Server.usdfint:
+                return Server.usdfint
             case _:
                 raise ValueError(f"Unset or invalid {env_var_name}: {current}")
 
@@ -309,7 +312,68 @@ def get_access_token(request: Request = None):
         import lsst.rsp.utils
 
         return lsst.rsp.utils.get_info()
+        # TODO: OSW-2050 Do we intend to keep supporting use of nd
+        # in personal notebooks in RSP ?
     except ImportError:
+        env_token = os.getenv("ACCESS_TOKEN")
+        if env_token is not None:
+            return env_token
+
+        if request is not None:
+            auth_header = request.headers.get("Authorization")
+            if auth_header is not None and " " in auth_header:
+                return auth_header.split(" ")[1]
+
+    raise HTTPException(
+        status_code=401, detail="RSP authentication token could not be retrieved by any method."
+    )
+
+
+def get_consdb_access_token(request: Request = None):
+    """ConsDB's nightly digest integration data will now be on usdf-rsp-int
+    So if the rest of the application is on usdf-rsp-dev, we need to feed
+    a different ACCESS_TOKEN through to ConsDB
+
+    Returns access token to be sent in headers as Auth Bearer
+
+    When called from the FastAPI web server in local development
+    the token is read from the `ACCESS_TOKEN` environment variable.
+
+    Otherwise we assume this is called from the FastAPI web server running
+    on the RSP and the token is read from the request headers.
+
+    Parameters
+    ----------
+    request : `fastapi.Request`, optional
+        The request object, if available. Used to
+        extract the token from headers.
+
+    Raises
+    ------
+    HTTPException
+        If the access token cannot be retrieved by any method.
+
+    Returns
+    -------
+    str or None
+        The access token if available, otherwise None.
+    """
+    try:
+        import lsst.rsp.utils
+
+        return lsst.rsp.utils.get_info()
+        # If in usdf-rsp-dev we're unable to access ConsDB from usdf-rsp-int
+    except ImportError:
+
+        active_environment = Server.get_url()
+        env_token_int = os.getenv("ACCESS_TOKEN_INT")
+        if active_environment is Server.usdfdev and env_token_int is not None:
+            import logging
+            logger = logging.getLogger("__name__")
+            logger.warning('Valerie you are in usdf-rsp-dev, we are accessing the int var though')
+            # Switch to providing the usdf-rsp-int access env var
+            return env_token_int
+
         env_token = os.getenv("ACCESS_TOKEN")
         if env_token is not None:
             return env_token

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -364,13 +364,13 @@ def get_consdb_access_token(request: Request = None):
         return lsst.rsp.utils.get_info()
         # If in usdf-rsp-dev we're unable to access ConsDB from usdf-rsp-int
     except ImportError:
-
         active_environment = Server.get_url()
         env_token_int = os.getenv("ACCESS_TOKEN_INT")
         if active_environment is Server.usdfdev and env_token_int is not None:
             import logging
+
             logger = logging.getLogger("__name__")
-            logger.warning('Valerie you are in usdf-rsp-dev, we are accessing the int var though')
+            logger.warning("Valerie you are in usdf-rsp-dev, we are accessing the int var though")
             # Switch to providing the usdf-rsp-int access env var
             return env_token_int
 

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from rubin_scheduler.scheduler.model_observatory import ModelObservatory
 
 from lsst.ts.logging_and_reporting.exceptions import BaseLogrepError, ConsdbQueryError
-from lsst.ts.logging_and_reporting.utils import get_access_token, make_json_safe
+from lsst.ts.logging_and_reporting.utils import get_access_token, get_consdb_access_token, make_json_safe
 
 from .. import __version__
 from .services.almanac_service import get_almanac
@@ -83,11 +83,13 @@ async def read_exposures(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
+    cdb_auth_token: str = Depends(get_consdb_access_token),
     auth_token: str = Depends(get_access_token),
 ):
     logger.info(f"Getting exposures for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}")
     try:
-        exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
+        # ConsDB only token
+        exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token=cdb_auth_token)
         on_sky_exposures = [exp for exp in exposures if exp.get("can_see_sky")]
         total_exposure_time = sum(exposure["exp_time"] for exposure in exposures)
         total_on_sky_exposure_time = sum(exp["exp_time"] for exp in on_sky_exposures)
@@ -99,7 +101,6 @@ async def read_exposures(
             dayObsEnd,
             instrument,
             exposures,
-            auth_token,
         )
 
         if not exposures_df.empty:
@@ -176,11 +177,11 @@ async def read_data_log(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    cdb_auth_token: str = Depends(get_consdb_access_token),
 ):
     logger.info(f"Getting data log for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}")
     try:
-        records = get_data_log(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
+        records = get_data_log(dayObsStart, dayObsEnd, instrument, auth_token=cdb_auth_token)
         return jsonable_encoder({"data_log": records})
 
     except ConsdbQueryError as ce:

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -179,7 +179,8 @@ def get_context_feed(
     """
     logger.info(f"Getting context feed data for start: {dayobs_start}, end: {dayobs_end}")
     try:
-        # Get connections to rubin_nights services
+        # Get connections to rubin_nights services,
+        # EFD, obsenv, narrative_log, and exposure_log used here
         endpoints = get_clients(auth_token=auth_token)
 
         # Convert dayobs_start and dayobs_end to t_start and t_end

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, Mock, patch
+from urllib.parse import urlparse
 
 import pandas as pd
 import pytest
@@ -9,9 +10,8 @@ from bokeh.plotting import figure
 from fastapi.testclient import TestClient
 from rubin_nights.connections import get_clients
 
-import lsst.ts.logging_and_reporting.utils as ut
 from lsst.ts.logging_and_reporting import __version__
-from lsst.ts.logging_and_reporting.utils import get_access_token
+from lsst.ts.logging_and_reporting.utils import get_access_token, get_consdb_access_token
 from lsst.ts.logging_and_reporting.web_app.main import app
 
 client = TestClient(app)
@@ -594,7 +594,8 @@ def mock_get_response():
 
     def response_json_payload():
         called_url = requests.get.call_args[0][0]
-        endpoint = called_url.replace(ut.Server.get_url(), "").split("?")[0]
+        url_parts = urlparse(called_url)
+        endpoint = url_parts.path
         return SERVICE_ENDPOINT_MOCK_RESPONSES[endpoint]
 
     response_get.json = response_json_payload
@@ -635,7 +636,8 @@ def mock_post_response():
 
     def response_json_payload():
         called_url = requests.post.call_args[0][0]
-        endpoint = called_url.replace(ut.Server.get_url(), "").split("?")[0]
+        url_parts = urlparse(called_url)
+        endpoint = url_parts.path
         return SERVICE_ENDPOINT_MOCK_RESPONSES[endpoint]
 
     response_post.json = response_json_payload
@@ -645,6 +647,7 @@ def mock_post_response():
 def _test_endpoint_auth_header(endpoint):
     headers = {"Authorization": "Bearer header-token"}
     response = client.get(endpoint, headers=headers)
+    print(f"{response=}")
     assert response.status_code == 200
 
 
@@ -826,6 +829,7 @@ def test_exposures_endpoint(mock_requests_get, mock_requests_post):
             }
         )
         app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+        app.dependency_overrides[get_consdb_access_token] = lambda: "dummy-consdb-token"
         app.dependency_overrides[get_clients] = lambda: {"efd": Mock()}
 
         response = client.get(endpoint)


### PR DESCRIPTION
Move our Nightly Digest development deployment to query data from usdf-rsp-int ConsDB where there will* be replicated data from the summit.
*usually replicated data from the summit, but also a test area for ConsDB for major changes (where it might be good for us to test against these changes too as integration)

Requires this other PR to be run locally or released in usdf-rsp-dev https://github.com/lsst-ts/ts_logging_frontend/pull/114
