### PR TITLE
OSW-2058: Refactor Jira Adapter & get_access_token

### DIFF
--- a/doc/news/OSW-2058.misc.rst
+++ b/doc/news/OSW-2058.misc.rst
@@ -1,0 +1,1 @@
+Refactor Jira adapter and generalise get_access_token to be token-agnostic.

--- a/python/lsst/ts/logging_and_reporting/exceptions.py
+++ b/python/lsst/ts/logging_and_reporting/exceptions.py
@@ -34,12 +34,10 @@ class BaseLogrepError(Warning):
     def __init__(self, error_message, error_code=None, status_code=None):
         Exception.__init__(self)
         self.error_message = error_message
-        if error_code is not None:
-            if isinstance(error_code, str) and len(error_code) > 8:
-                raise ValueError(f'error_code "{error_code}" too big')
-            self.error_code = error_code
-        else:
-            self.error_code = None
+
+        if error_code and len(error_code) > 8:
+            raise ValueError(f'error_code "{error_code}" too big')
+        self.error_code = error_code  # always assign, even if None or ""
 
         if status_code is not None:
             self.status_code = status_code or self.status_code

--- a/python/lsst/ts/logging_and_reporting/exceptions.py
+++ b/python/lsst/ts/logging_and_reporting/exceptions.py
@@ -34,13 +34,13 @@ class BaseLogrepError(Warning):
     def __init__(self, error_message, error_code=None, status_code=None):
         Exception.__init__(self)
         self.error_message = error_message
-        if error_code:
-            if len(error_code) > 8:
+        if error_code is not None:
+            if isinstance(error_code, str) and len(error_code) > 8:
                 raise ValueError(f'error_code "{error_code}" too big')
             self.error_code = error_code
+        else:
+            self.error_code = None
 
-        if error_code is not None:
-            self.error_code = error_code
         if status_code is not None:
             self.status_code = status_code or self.status_code
 

--- a/python/lsst/ts/logging_and_reporting/jira.py
+++ b/python/lsst/ts/logging_and_reporting/jira.py
@@ -1,4 +1,10 @@
-import os
+"""
+For more information on the REST API endpoints refer to:
+- https://developer.atlassian.com/cloud/jira/platform/rest/v3
+- https://developer.atlassian.com/cloud/jira/platform/\
+    basic-auth-for-rest-apis/
+"""
+
 import traceback
 from datetime import datetime
 from urllib.parse import quote
@@ -8,10 +14,13 @@ from pytz import timezone
 
 import lsst.ts.logging_and_reporting.exceptions as ex
 import lsst.ts.logging_and_reporting.utils as ut
-from lsst.ts.logging_and_reporting.source_adapters import SourceAdapter
 
 OBS_SYSTEMS_FIELD = "customfield_10476"
 TIME_LOST_FIELD = "customfield_10106"
+
+dayobs_str_format = "%Y-%m-%d %H:%M"
+timestamp_input_format = "%Y-%m-%dT%H:%M:%S.%f%z"
+timestamp_output_format = "%Y-%m-%d %H:%M:%S"
 
 
 def get_system_names(jira_system_field):
@@ -34,7 +43,7 @@ def get_system_names(jira_system_field):
     return systems
 
 
-class JiraAdapter(SourceAdapter):
+class JiraAdapter:
     EXCLUDED_STATUSES = ["Cancelled"]
     ISSUE_FIELDS = [
         "key",
@@ -50,123 +59,113 @@ class JiraAdapter(SourceAdapter):
     def __init__(
         self,
         *,
-        min_dayobs=None,
-        max_dayobs=None,
-        limit=None,
-        verbose=False,
-        warning=True,
+        jira_token=None,
+        jira_hostname=None,
     ):
-        super().__init__(
-            max_dayobs=max_dayobs,
-            min_dayobs=min_dayobs,
-            limit=limit,
-            verbose=verbose,
-            warning=warning,
-        )
-        self.issues = None
+        self.jira_token = jira_token
+        self.jira_hostname = jira_hostname
+        self.base_url = f"https://{self.jira_hostname}"
+        self.headers = {
+            "Authorization": f"Basic {self.jira_token}",
+            "content-type": "application/json",
+        }
 
-    def fetch_issues(self):
-        """Query JIRA issues for the configured dayobs range, save and
-        return them via self.issues."""
-        if self.issues is None:
-            self.issues = self.get_jira_obs_report()
-        return self.issues
+    def get_users_timezone(self):
+        users_url = f"{self.base_url}/rest/api/latest/myself"
+        response = requests.get(users_url, headers=self.headers)
+        if response.status_code == 200:
+            return timezone(response.json()["timeZone"])
+        else:
+            raise Exception(
+                f"Error getting user timezone from {self.jira_hostname}: "
+                f"{response.status_code} - {response.text}"
+            )
 
-    def get_jira_obs_report(self):
-        """From LOVE-Manager, connect to the Rubin Observatory JIRA Cloud
-        REST API to query all issues of the OBS project for a certain obs day.
+    def _search(self, jql_query, fields):
+        url = f"{self.base_url}/rest/api/latest/search/jql?jql={quote(jql_query)}&fields={fields}"
 
-        For more information on the REST API endpoints refer to:
-        - https://developer.atlassian.com/cloud/jira/platform/rest/v3
-        - https://developer.atlassian.com/cloud/jira/platform/\
-            basic-auth-for-rest-apis/
+        try:
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            msg = f"Error querying Jira: {response.status_code} - {response.text}"
+            traceback.print_exc()
+            raise ex.BaseLogrepError(msg) from err
+        except requests.exceptions.ConnectionError as err:
+            msg = f"Error connecting to Jira. {str(err)}"
+            traceback.print_exc()
+            raise ex.BaseLogrepError(msg) from err
+
+        return response.json().get("issues", [])
+
+    def get_obs_issues(self, min_dayobs, max_dayobs):
+        """Query all issues of the OBS project for a specified range
+        of observation dates.
 
         Notes
         -----
         The JIRA REST API query is based on the user timezone so
-        we need to specify UTC timezone and we expect max_dayobs
-        and min_dayobs to be given in UTC.
+        we need to specify UTC timezone and we expect min_dayobs
+        and max_dayobs to be given in UTC.
 
         Returns
         -------
         List
-            List of dictionaries containing the following keys:
+            List of issue dictionaries containing the following keys:
             - key: The issue key
             - summary: The issue summary
-            - time_lost: The time lost in the issue
-            - reporter: The issue reporter
+            - updated: The timestamp of the most recent update
             - created: The issue creation date
+            - status: The current status of issue
+            - system: The relevant system, e.g. "Simonyi"
+            - isNew: True if created within specified range
+            - url: The URl of the issue
+            - time_lost: The time lost in the issue
         """
-        try:
-            headers = {
-                "Authorization": f"Basic {os.environ.get('JIRA_API_TOKEN')}",
-                "content-type": "application/json",
-            }
+        user_timezone = self.get_users_timezone()
 
-            # needs to be tai, is not yet tai
-            start_dayobs_utc = ut.get_utc_datetime_from_dayobs_str(self.min_dayobs)
-            end_dayobs_utc = ut.get_utc_datetime_from_dayobs_str(self.max_dayobs)
+        # A bunch of date formatting stuff that could maybe be collected
+        # in a function.
+        start_dayobs_utc = ut.get_utc_datetime_from_dayobs_str(min_dayobs)
+        end_dayobs_utc = ut.get_utc_datetime_from_dayobs_str(max_dayobs)
 
-            # Get user's timezone
-            url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/myself"
-            response = requests.get(url, headers=headers)
-            if response.status_code == 200:
-                user_timezone = timezone(response.json()["timeZone"])
-            else:
-                raise Exception(
-                    f"Error getting user timezone from {os.environ.get('JIRA_API_HOSTNAME')}: "
-                    f"{response.status_code} - {response.text}"
-                )
+        # convert the utc times to user timezone
+        start_dayobs_user = start_dayobs_utc.astimezone(user_timezone)
+        end_dayobs_user = end_dayobs_utc.astimezone(user_timezone)
 
-            # convert the utc times to user timezone
-            start_dayobs_user = start_dayobs_utc.astimezone(user_timezone)
-            end_dayobs_user = end_dayobs_utc.astimezone(user_timezone)
+        start_dayobs_str = start_dayobs_user.strftime(dayobs_str_format)
+        end_dayobs_str = end_dayobs_user.strftime(dayobs_str_format)
 
-            start_dayobs_str = start_dayobs_user.strftime("%Y-%m-%d %H:%M")
-            end_dayobs_str = end_dayobs_user.strftime("%Y-%m-%d %H:%M")
+        # JQL query to get all issues in the OBS project created between
+        # the specified dayobs range, excluding certain statuses
+        status_exclusions = " ".join(f'AND status != "{s}"' for s in self.EXCLUDED_STATUSES)
+        jql_query = (
+            f"project = OBS {status_exclusions} "
+            f'AND ((created >= "{start_dayobs_str}" '
+            f'AND created < "{end_dayobs_str}") '
+            f'OR (updated >= "{start_dayobs_str}" '
+            f'AND updated < "{end_dayobs_str}"))'
+        )
+        fields = ",".join(self.ISSUE_FIELDS)
 
-            # JQL query to get all issues in the OBS project created between
-            # the specified dayobs range, excluding certain statuses
-            status_exclusions = " ".join(f'AND status != "{s}"' for s in self.EXCLUDED_STATUSES)
-            jql_query = (
-                f"project = OBS {status_exclusions} "
-                f'AND ((created >= "{start_dayobs_str}" '
-                f'AND created < "{end_dayobs_str}") '
-                f'OR (updated >= "{start_dayobs_str}" '
-                f'AND updated < "{end_dayobs_str}"))'
-            )
-            fields = ",".join(self.ISSUE_FIELDS)
-            url = f"https://{os.environ.get('JIRA_API_HOSTNAME')}/rest/api/latest/search/jql?jql={quote(jql_query)}&fields={fields}"
-            response = requests.get(url, headers=headers)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            # Invalid URL?, etc.
-            msg = f"Error getting issues from {os.environ.get('JIRA_API_HOSTNAME')}: "
-            f"{response.status_code} - {response.text}"
-            traceback.print_exc()
-            raise ex(f"Upstream error: {msg}") from err
-        except requests.exceptions.ConnectionError as err:
-            msg = f"Error connecting to Jira.{str(err)}."
-            traceback.print_exc()
-            raise ex.BaseLogrepError(msg) from err
+        issues = self._search(jql_query, fields=fields)
 
-        issues = response.json()["issues"]
         return [
             {
                 "key": issue["key"],
                 "summary": issue["fields"]["summary"],
-                "updated": datetime.strptime(issue["fields"]["updated"], "%Y-%m-%dT%H:%M:%S.%f%z").strftime(
-                    "%Y-%m-%d %H:%M:%S"
+                "updated": datetime.strptime(issue["fields"]["updated"], timestamp_input_format).strftime(
+                    timestamp_output_format
                 ),
-                "created": datetime.strptime(issue["fields"]["created"], "%Y-%m-%dT%H:%M:%S.%f%z").strftime(
-                    "%Y-%m-%d %H:%M:%S"
+                "created": datetime.strptime(issue["fields"]["created"], timestamp_input_format).strftime(
+                    timestamp_output_format
                 ),
                 "status": issue["fields"]["status"]["name"],
                 "system": get_system_names(issue["fields"][OBS_SYSTEMS_FIELD]),
-                "isNew": datetime.strptime(issue["fields"]["created"], "%Y-%m-%dT%H:%M:%S.%f%z")
+                "isNew": datetime.strptime(issue["fields"]["created"], timestamp_input_format)
                 >= start_dayobs_user
-                and datetime.strptime(issue["fields"]["created"], "%Y-%m-%dT%H:%M:%S.%f%z") < end_dayobs_user,
-                "url": f"https://{os.environ.get('JIRA_API_HOSTNAME')}/browse/{issue['key']}",
+                and datetime.strptime(issue["fields"]["created"], timestamp_input_format) < end_dayobs_user,
+                "url": f"{self.base_url}/browse/{issue['key']}",
                 "time_lost": issue["fields"][TIME_LOST_FIELD],
             }
             for issue in issues

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -40,6 +40,25 @@ from fastapi import HTTPException, Request
 # in a Database or API query string.
 
 
+AUTH_SOURCES = {
+    "rsp": {
+        "env_var": "ACCESS_TOKEN",
+        "label": "RSP",
+        "use_rsp_utils": True,
+    },
+    "jira": {
+        "env_var": "JIRA_API_TOKEN",
+        "label": "Jira",
+        "use_rsp_utils": False,
+    },
+    "zephyr": {
+        "env_var": "ZEPHYR_API_TOKEN",
+        "label": "Zephyr",
+        "use_rsp_utils": False,
+    },
+}
+
+
 def date_hr_min(iso_dt_str):
     # return YYYY-MM-DD HH:MM
     return str(dt.datetime.fromisoformat(iso_dt_str))[:16]
@@ -277,57 +296,166 @@ class Server:
                 raise ValueError(f"Unset or invalid {env_var_name}: {current}")
 
 
-def get_access_token(request: Request = None):
-    """Return access token to be sent in headers as Auth Bearer
+def get_access_token(source: str = "rsp"):
+    """Create a FastAPI dependency that retrieves an authentication token.
 
-    When calling from a notebook on the RSP `lsst.rsp.utils.get_access_token`
-    is used to get the token from the active client session.
+    This is a dependency factory that returns a callable suitable for use with
+    ``fastapi.Depends``. The returned dependency retrieves an authentication
+    token for the specified source using a sequence of fallback methods.
 
-    When called from the FastAPI web server in local development
-    the token is read from the `ACCESS_TOKEN` environment variable.
-
-    Otherwise we assume this is called from the FastAPI web server running
-    on the RSP and the token is read from the request headers.
+    Retrieval order
+    ---------------
+    1. If enabled for the source, attempt to retrieve the token using
+       ``lsst.rsp._services.RSPDiscovery`` (RSP notebook environments).
+    2. Read the token from the configured environment variable.
+    3. Extract the token from the ``Authorization`` header of the incoming
+       request (if a request object is available).
 
     Parameters
     ----------
-    request : `fastapi.Request`, optional
-        The request object, if available. Used to
-        extract the token from headers.
+    source : `str`, optional
+        The authentication source identifier. Must be a key in
+        ``AUTH_SOURCES``. Defaults to ``"rsp"``.
+
+    Returns
+    -------
+    callable
+        A dependency function that FastAPI will call per request. The returned
+        function accepts an optional ``fastapi.Request`` and returns a token.
 
     Raises
     ------
     HTTPException
-        If the access token cannot be retrieved by any method.
+        If a token cannot be retrieved by any method. The exception message
+        includes the configured source label for clarity.
 
-    Returns
-    -------
-    str or None
-        The access token if available, otherwise None.
+    Notes
+    -----
+    This function is a factory and must be called when used with
+    ``fastapi.Depends``, e.g. ``Depends(get_access_token("jira"))``.
     """
-    try:
-        import lsst.rsp.utils
+    config = AUTH_SOURCES[source]
 
-        return lsst.rsp.utils.get_info()
-    except ImportError:
-        env_token = os.getenv("ACCESS_TOKEN")
+    def dependency(request: Request = None):
+        """Retrieve an authentication token for the configured source.
+
+        Parameters
+        ----------
+        request : `fastapi.Request`, optional
+            The incoming request object. Used to extract the token from
+            request headers when available.
+
+        Returns
+        -------
+        str
+            The authentication token.
+
+        Raises
+        ------
+        HTTPException
+            If a token cannot be retrieved by any method.
+        """
+        # Try RSP notebook utils (only if enabled)
+        if config.get("use_rsp_utils"):
+            # Preferred API
+            try:
+                from lsst.rsp._services import RSPDiscovery
+
+                token = RSPDiscovery.get_token()
+                if token:
+                    return token
+            except (ImportError, Exception):
+                pass
+
+            # Backward compatibility fallback
+            try:
+                import lsst.rsp.utils
+
+                token = lsst.rsp.utils.get_access_token()
+                if token:
+                    return token
+            except ImportError:
+                pass
+
+        # Try env variable
+        env_token = os.getenv(config["env_var"])
         if env_token is not None:
             return env_token
 
+        # Try request headers
         if request is not None:
             auth_header = request.headers.get("Authorization")
-            if auth_header is not None and " " in auth_header:
+            if auth_header and " " in auth_header:
                 return auth_header.split(" ")[1]
 
-    raise HTTPException(
-        status_code=401, detail="RSP authentication token could not be retrieved by any method."
-    )
+        raise HTTPException(
+            status_code=401,
+            detail=f"{config['label']} authentication token could not be retrieved by any method.",
+        )
+
+    return dependency
 
 
-def get_auth_header(token=None):
-    """return dict obj for request auth headers"""
-    bearer_token = token if token is not None else get_access_token()
-    return {"Authorization": f"Bearer {bearer_token}"}
+def get_auth_header(token: str | None):
+    """Construct an HTTP Authorization header using a bearer token.
+
+    Parameters
+    ----------
+    token : `str` or `None`
+        The authentication token to include in the header.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the ``Authorization`` header with the
+        bearer token.
+
+    Raises
+    ------
+    ValueError
+        If ``token`` is None or empty.
+
+    Notes
+    -----
+    This function does not retrieve tokens. Token acquisition should be
+    handled upstream (e.g. via FastAPI dependencies).
+    """
+    if not token:
+        raise ValueError("Auth token is required")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def get_jira_hostname():
+    """Retrieve the Jira API hostname from environment configuration.
+
+    This function is intended for use as a FastAPI dependency to supply the
+    Jira service hostname to endpoints or downstream clients.
+
+    The hostname is read from the ``JIRA_API_HOSTNAME`` environment variable.
+
+    Returns
+    -------
+    str
+        The Jira API hostname.
+
+    Raises
+    ------
+    HTTPException
+        If the hostname is not defined in the environment. Returns a 500
+        status code indicating a server configuration error.
+
+    Notes
+    -----
+    This function only retrieves configuration and does not perform any
+    network validation of the hostname.
+    """
+    hostname = os.getenv("JIRA_API_HOSTNAME")
+    if not hostname:
+        raise HTTPException(
+            status_code=500,
+            detail="Jira hostname not configured",
+        )
+    return hostname
 
 
 def stringify_special_floats(val):

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -296,20 +296,90 @@ class Server:
                 raise ValueError(f"Unset or invalid {env_var_name}: {current}")
 
 
-def get_access_token(source: str = "rsp"):
-    """Create a FastAPI dependency that retrieves an authentication token.
+def retrieve_access_token(config: dict, request: Request = None) -> str:
+    """Retrieve an authentication token using a configurable sequence of
+    fallback methods.
 
-    This is a dependency factory that returns a callable suitable for use with
-    ``fastapi.Depends``. The returned dependency retrieves an authentication
-    token for the specified source using a sequence of fallback methods.
+    This function is framework-agnostic and can be used anywhere token
+    retrieval is needed, without relying on FastAPI.
 
     Retrieval order
     ---------------
-    1. If enabled for the source, attempt to retrieve the token using
-       ``lsst.rsp._services.RSPDiscovery`` (RSP notebook environments).
-    2. Read the token from the configured environment variable.
-    3. Extract the token from the ``Authorization`` header of the incoming
-       request (if a request object is available).
+    1. Preferred RSP notebook API
+    (``lsst.rsp._services.RSPDiscovery.get_token``) if enabled.
+    2. Fallback notebook API (``lsst.rsp.utils.get_access_token``) for
+    backward compatibility.
+    3. Environment variable specified in the config.
+    4. Authorization header from the provided request, if any.
+
+    Parameters
+    ----------
+    config : `dict`
+        Configuration for the authentication source. Must contain keys:
+        - ``"use_rsp_utils"`` (`bool`)
+        - ``"env_var"`` (`str`)
+        - ``"label"`` (`str`)
+    request : `fastapi.Request`, optional
+        FastAPI request object used to extract the token from headers.
+        Default is None.
+
+    Returns
+    -------
+    str
+        The resolved authentication token.
+
+    Raises
+    ------
+    HTTPException
+        If no token could be retrieved by any method.
+    """
+
+    # Try RSP notebook utils (only if enabled)
+    if config.get("use_rsp_utils"):
+        # Preferred API
+        try:
+            from lsst.rsp._services import RSPDiscovery
+
+            token = RSPDiscovery.get_token()
+            if token:
+                return token
+        except (ImportError, Exception):
+            pass
+
+        # Backward compatibility fallback
+        try:
+            import lsst.rsp.utils
+
+            token = lsst.rsp.utils.get_access_token()
+            if token:
+                return token
+        except ImportError:
+            pass
+
+    # Try env variable
+    env_token = os.getenv(config["env_var"])
+    if env_token is not None:
+        return env_token
+
+    # Try request headers
+    if request is not None:
+        auth_header = request.headers.get("Authorization")
+        if auth_header and " " in auth_header:
+            return auth_header.split(" ")[1]
+
+    raise HTTPException(
+        status_code=401,
+        detail=f"{config['label']} authentication token could not be retrieved by any method.",
+    )
+
+
+def get_access_token(source: str = "rsp"):
+    """FastAPI dependency factory that provides an authentication token for a
+    given source.
+
+    This is a thin wrapper around ``retrieve_access_token`` that returns a
+    callable suitable for ``fastapi.Depends``. Each call to the dependency
+    will attempt to resolve a token according to the configured source.
 
     Parameters
     ----------
@@ -333,65 +403,38 @@ def get_access_token(source: str = "rsp"):
     -----
     This function is a factory and must be called when used with
     ``fastapi.Depends``, e.g. ``Depends(get_access_token("jira"))``.
+
+    Usage in FastAPI routes:
+
+        from fastapi import Depends
+
+        @app.get("/example")
+        def endpoint(auth_token: str = Depends(get_access_token("jira"))):
+            return {"token": auth_token}
     """
     config = AUTH_SOURCES[source]
 
     def dependency(request: Request = None):
-        """Retrieve an authentication token for the configured source.
+        """
+        FastAPI dependency function for retrieving an authentication token.
 
         Parameters
         ----------
         request : `fastapi.Request`, optional
-            The incoming request object. Used to extract the token from
-            request headers when available.
+            The incoming request object, used to extract the token from
+            headers.
 
         Returns
         -------
         str
-            The authentication token.
+            Authentication token retrieved using ``retrieve_access_token``.
 
         Raises
         ------
         HTTPException
-            If a token cannot be retrieved by any method.
+            If no token could be resolved.
         """
-        # Try RSP notebook utils (only if enabled)
-        if config.get("use_rsp_utils"):
-            # Preferred API
-            try:
-                from lsst.rsp._services import RSPDiscovery
-
-                token = RSPDiscovery.get_token()
-                if token:
-                    return token
-            except (ImportError, Exception):
-                pass
-
-            # Backward compatibility fallback
-            try:
-                import lsst.rsp.utils
-
-                token = lsst.rsp.utils.get_access_token()
-                if token:
-                    return token
-            except ImportError:
-                pass
-
-        # Try env variable
-        env_token = os.getenv(config["env_var"])
-        if env_token is not None:
-            return env_token
-
-        # Try request headers
-        if request is not None:
-            auth_header = request.headers.get("Authorization")
-            if auth_header and " " in auth_header:
-                return auth_header.split(" ")[1]
-
-        raise HTTPException(
-            status_code=401,
-            detail=f"{config['label']} authentication token could not be retrieved by any method.",
-        )
+        return retrieve_access_token(config, request)
 
     return dependency
 

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -9,7 +9,11 @@ from fastapi.responses import JSONResponse
 from rubin_scheduler.scheduler.model_observatory import ModelObservatory
 
 from lsst.ts.logging_and_reporting.exceptions import BaseLogrepError, ConsdbQueryError
-from lsst.ts.logging_and_reporting.utils import get_access_token, make_json_safe
+from lsst.ts.logging_and_reporting.utils import (
+    get_access_token,
+    get_jira_hostname,
+    make_json_safe,
+)
 
 from .. import __version__
 from .services.almanac_service import get_almanac
@@ -29,6 +33,10 @@ from .services.rubin_nights_service import (
     get_visits,
 )
 from .services.scheduler_service import create_visit_skymaps, get_expected_exposures, prepare_visit_maps_data
+
+# Auth dependencies (instantiated once for reuse and testing)
+rsp_auth = get_access_token()
+jira_auth = get_access_token("jira")
 
 logger = logging.getLogger("uvicorn.error")
 logger.setLevel(logging.DEBUG)
@@ -83,7 +91,7 @@ async def read_exposures(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     logger.info(f"Getting exposures for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}")
     try:
@@ -176,7 +184,7 @@ async def read_data_log(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     logger.info(f"Getting data log for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}")
     try:
@@ -192,12 +200,19 @@ async def read_data_log(
 
 
 @app.get("/jira-tickets")
-async def read_jira_tickets(request: Request, dayObsStart: int, dayObsEnd: int, instrument: str):
+async def read_jira_tickets(
+    request: Request,
+    dayObsStart: int,
+    dayObsEnd: int,
+    instrument: str,
+    auth_token: str = Depends(jira_auth),
+    jira_hostname: str = Depends(get_jira_hostname),
+):
     logger.info(
         f"Getting jira tickets for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}"
     )
     try:
-        tickets = get_jira_tickets(dayObsStart, dayObsEnd, instrument)
+        tickets = get_jira_tickets(dayObsStart, dayObsEnd, instrument, auth_token, jira_hostname)
         return {"issues": tickets}
     except BaseLogrepError as ble:
         logger.error(f"Jira API error in /jira-tickets: {ble}")
@@ -224,7 +239,7 @@ async def read_narrative_log(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     logger.info(
         f"Getting Narrative Log records for dayObsStart: {dayObsStart}, "
@@ -250,7 +265,7 @@ async def read_exposure_flags(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     logger.info(
         f"Getting Exposure Log flags for dayObsStart: {dayObsStart}, "
@@ -272,7 +287,7 @@ async def read_exposure_entries(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     logger.info(
         f"Getting Exposure Log entries for dayObsStart: {dayObsStart}, "
@@ -293,7 +308,7 @@ async def read_nightreport(
     request: Request,
     dayObsStart: int,
     dayObsEnd: int,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     try:
         records = get_night_reports(dayObsStart, dayObsEnd, auth_token=auth_token)
@@ -310,7 +325,7 @@ async def read_context_feed(
     request: Request,
     dayObsStart: int,
     dayObsEnd: int,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     try:
         (efd_and_messages, cols) = get_context_feed(dayObsStart, dayObsEnd, auth_token=auth_token)
@@ -331,7 +346,7 @@ async def multi_night_visit_maps(
     instrument: str,
     planisphereOnly: bool = False,
     appletMode: bool = False,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(rsp_auth),
 ):
     """Generate multi-night visit maps using Bokeh.
     Parameters
@@ -391,7 +406,6 @@ async def survey_progress_map(
     request: Request,
     dayObs: int,
     instrument: str,
-    auth_token: str = Depends(get_access_token),
 ):
     """Generate a survey progress map for a given night using Bokeh.
 
@@ -403,8 +417,6 @@ async def survey_progress_map(
         Date in YYYYMMDD format.
     instrument : `str`
         Instrument name (e.g., 'lsstCam', 'latiss', etc.).
-    auth_token : `str`
-        Authentication token (injected by FastAPI dependency).
 
     Returns
     -------

--- a/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/jira_service.py
@@ -85,15 +85,65 @@ def filter_tickets_without_instrument_match(tickets, instrument):
     return [ticket for ticket in tickets if not_matches(ticket)]
 
 
-def get_jira_tickets(dayobs_start: int, dayobs_end: int, telescope: str) -> list[dict]:
+def get_jira_tickets(
+    dayobs_start: int,
+    dayobs_end: int,
+    telescope: str,
+    jira_token: str = None,
+    jira_hostname: str = None,
+) -> list[dict]:
+    """Retrieve and filter Jira tickets for a given dayobs range and telescope.
+
+    This service queries Jira for observation-related tickets within the
+    specified dayobs range, then applies instrument-based filtering logic
+    to return only relevant tickets for the requested telescope.
+
+    Parameters
+    ----------
+    dayobs_start : `int`
+        The start of the dayobs range (inclusive), formatted as YYYYMMDD.
+    dayobs_end : `int`
+        The end of the dayobs range (exclusive), formatted as YYYYMMDD.
+    telescope : `str`
+        The telescope or instrument name used to filter returned tickets.
+    jira_token : `str`, optional
+        Authentication token for Jira API access.
+    jira_hostname : `str`, optional
+        Hostname for the Jira API.
+
+    Returns
+    -------
+    list of `dict`
+        A list of Jira ticket objects matching the specified criteria.
+        Returns an empty list if no tickets are found.
+
+    Notes
+    -----
+    - Tickets are initially retrieved using the Jira adapter over the
+      full dayobs range.
+    - If ``telescope`` is present in ``INSTRUMENT_EXCLUDE_MAP``, tickets
+      are filtered by excluding those matching specified instruments.
+    - Otherwise, only tickets matching the given ``telescope`` are included.
+    - Filtering is performed using helper functions that match or exclude
+      tickets based on instrument/system fields.
+
+    Raises
+    ------
+    None
+        This function does not raise exceptions directly, but may propagate
+        exceptions raised by the Jira adapter or underlying network calls.
+    """
     logger.info(f"Jira service: start: {dayobs_start}, end: {dayobs_end} and telescope: {telescope}")
 
     jira = JiraAdapter(
-        max_dayobs=dayobs_end,
-        min_dayobs=dayobs_start,
+        jira_token=jira_token,
+        jira_hostname=jira_hostname,
     )
-    logger.info(f"max_dayobs: {jira.max_dayobs}, min_dayobs: {jira.min_dayobs}, telescope: {telescope}")
-    tickets = jira.fetch_issues()
+
+    tickets = jira.get_obs_issues(
+        min_dayobs=dayobs_start,
+        max_dayobs=dayobs_end,
+    )
     if not tickets:
         logger.warning("No Jira tickets found for the specified date range and telescope.")
         return []

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, Mock, patch
 
@@ -11,8 +10,8 @@ from rubin_nights.connections import get_clients
 
 import lsst.ts.logging_and_reporting.utils as ut
 from lsst.ts.logging_and_reporting import __version__
-from lsst.ts.logging_and_reporting.utils import get_access_token
-from lsst.ts.logging_and_reporting.web_app.main import app
+from lsst.ts.logging_and_reporting.utils import get_jira_hostname
+from lsst.ts.logging_and_reporting.web_app.main import app, jira_auth, rsp_auth
 
 client = TestClient(app)
 
@@ -642,44 +641,37 @@ def mock_post_response():
     return response_post
 
 
-def _test_endpoint_auth_header(endpoint):
-    headers = {"Authorization": "Bearer header-token"}
-    response = client.get(endpoint, headers=headers)
+def _test_endpoint_authentication(endpoint, monkeypatch):
+    # Header auth
+    response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
     assert response.status_code == 200
 
-
-def _test_endpoint_auth_env_var(endpoint):
-    os.environ["ACCESS_TOKEN"] = "env-token"
+    # Env auth
+    monkeypatch.setenv("ACCESS_TOKEN", "env-token")
     response = client.get(endpoint)
     assert response.status_code == 200
-    del os.environ["ACCESS_TOKEN"]
+    monkeypatch.delenv("ACCESS_TOKEN", raising=False)
 
+    # RSP utils (RSPDiscovery)
+    mock_rspdiscovery = Mock()
+    mock_rspdiscovery.get_token.return_value = "mocked-discovery-token"
 
-def _test_endpoint_auth_rsp_utils(endpoint):
     mock_lsst = Mock()
-    mock_lsst.rsp.utils.get_info.return_value = "mocked-token"
+    mock_lsst.rsp._services.RSPDiscovery = mock_rspdiscovery
 
     with patch.dict(
         "sys.modules",
         {
             "lsst": mock_lsst,
-            "lsst.rsp.utils": mock_lsst.rsp.utils,
+            "lsst.rsp._services": mock_lsst.rsp._services,
         },
     ):
         response = client.get(endpoint)
         assert response.status_code == 200
 
-
-def _test_endpoint_no_auth(endpoint):
+    # No auth --> 401
     response = client.get(endpoint)
     assert response.status_code == 401
-
-
-def _test_endpoint_authentication(endpoint):
-    _test_endpoint_auth_header(endpoint)
-    _test_endpoint_auth_env_var(endpoint)
-    _test_endpoint_auth_rsp_utils(endpoint)
-    _test_endpoint_no_auth(endpoint)
 
 
 @pytest.fixture
@@ -714,11 +706,11 @@ def test_version_endpoint():
     assert data["version"] == __version__
 
 
-def test_nightreport_endpoint(mock_requests_get):
+def test_nightreport_endpoint(mock_requests_get, monkeypatch):
     endpoint = "/night-reports?dayObsStart=20250730&dayObsEnd=20250731"
-    _test_endpoint_authentication(endpoint)
+    _test_endpoint_authentication(endpoint, monkeypatch)
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
     response = client.get(endpoint)
     assert response.status_code == 200
     data = response.json()
@@ -745,14 +737,14 @@ def test_nightreport_endpoint(mock_requests_get):
     ]
     for param in expected_params:
         assert param in report, f"Missing {param} in night report: {report}"
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
-def test_exposure_entries_endpoint(mock_requests_get):
+def test_exposure_entries_endpoint(mock_requests_get, monkeypatch):
     endpoint = "/exposure-entries?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
-    _test_endpoint_authentication(endpoint)
+    _test_endpoint_authentication(endpoint, monkeypatch)
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
     response = client.get(endpoint)
     assert response.status_code == 200
     data = response.json()
@@ -778,12 +770,12 @@ def test_exposure_entries_endpoint(mock_requests_get):
     for entry in data["exposure_entries"]:
         for param in expected_entry_params:
             assert param in entry, f"Missing {param} in exposure entry: {entry}"
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
-def test_exposures_endpoint(mock_requests_get, mock_requests_post):
+def test_exposures_endpoint(mock_requests_get, mock_requests_post, monkeypatch):
     endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
-    _test_endpoint_authentication(endpoint)
+    _test_endpoint_authentication(endpoint, monkeypatch)
 
     with (
         patch("lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome") as mock_open_close,
@@ -825,7 +817,7 @@ def test_exposures_endpoint(mock_requests_get, mock_requests_post):
                 "visit_gap": [3],
             }
         )
-        app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+        app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
         app.dependency_overrides[get_clients] = lambda: {"efd": Mock()}
 
         response = client.get(endpoint)
@@ -857,8 +849,65 @@ def test_exposures_endpoint(mock_requests_get, mock_requests_post):
         assert data["exposures_count"] == 1
         assert data["open_dome_times"] == []
 
-        app.dependency_overrides.pop(get_access_token, None)
+        app.dependency_overrides.pop(rsp_auth, None)
         app.dependency_overrides.pop(get_clients, None)
+
+
+def test_jira_endpoint_authentication(monkeypatch):
+    endpoint = "/jira-tickets?dayObsStart=1&dayObsEnd=2&instrument=LATISS"
+
+    # Mock service
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_jira_tickets",
+        lambda *args, **kwargs: [],
+    )
+
+    monkeypatch.setenv("JIRA_API_HOSTNAME", "https://fake-jira-host")
+
+    # Header auth
+    response = client.get(endpoint, headers={"Authorization": "Bearer test"})
+    assert response.status_code == 200
+
+    # Env auth
+    monkeypatch.setenv("JIRA_API_TOKEN", "env-token")
+    response = client.get(endpoint)
+    assert response.status_code == 200
+
+    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+    monkeypatch.delenv("JIRA_API_HOSTNAME", raising=False)
+
+    # No auth --> 401
+    response = client.get(endpoint)
+    assert response.status_code == 401
+
+
+def test_jira_tickets_endpoint(mock_requests_get, monkeypatch):
+    endpoint = "/jira-tickets?dayObsStart=20250730&dayObsEnd=20250731&instrument=LATISS"
+
+    # Mock service layer
+    mock_tickets = [{"key": "OBS-1", "summary": "Test ticket"}]
+
+    monkeypatch.setattr(
+        "lsst.ts.logging_and_reporting.web_app.main.get_jira_tickets",
+        lambda *args, **kwargs: mock_tickets,
+    )
+
+    # Override dependencies
+    app.dependency_overrides[jira_auth] = lambda: "dummy-token"
+    app.dependency_overrides[get_jira_hostname] = lambda: "mock-host"
+
+    response = client.get(endpoint)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "issues" in data
+    assert data["issues"] == mock_tickets
+    assert isinstance(data["issues"], list)
+
+    # Cleanup
+    app.dependency_overrides.pop(jira_auth, None)
+    app.dependency_overrides.pop(get_jira_hostname, None)
 
 
 def test_almanac_endpoint(monkeypatch):
@@ -912,11 +961,11 @@ def test_context_feed_endpoint(monkeypatch):
     )
 
     # Authentication test --
-    _test_endpoint_authentication(endpoint)
+    _test_endpoint_authentication(endpoint, monkeypatch)
 
     # API test --
     # Override token-fetching dependency
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     # Make request
     response = client.get(endpoint)
@@ -934,7 +983,7 @@ def test_context_feed_endpoint(monkeypatch):
             assert col in record
 
     # Remove override
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
     # Error-path API test --
     # Simulate a service failure by patching get_context_feed
@@ -948,7 +997,7 @@ def test_context_feed_endpoint(monkeypatch):
     )
 
     # Override token again
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     # Expect API to return 500 with exception message
     response = client.get(endpoint)
@@ -956,7 +1005,7 @@ def test_context_feed_endpoint(monkeypatch):
     assert response.json()["detail"] == "failure"
 
     # Clean up override
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
 @pytest.fixture
@@ -1018,7 +1067,7 @@ def test_visit_maps_applet_mode_planisphere_only(
     mock_observatory_instance = MagicMock()
     mock_observatory.return_value = mock_observatory_instance
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     response = client.get(
         "/multi-night-visit-maps",
@@ -1046,7 +1095,7 @@ def test_visit_maps_applet_mode_planisphere_only(
     assert call_kwargs["applet_mode"] is True
     assert call_kwargs["timezone"] == "UTC"
 
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
 @patch("lsst.ts.logging_and_reporting.web_app.main.get_visits")
@@ -1069,7 +1118,7 @@ def test_visit_maps_full_mode_both_maps(
     mock_observatory_instance = MagicMock()
     mock_observatory.return_value = mock_observatory_instance
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     response = client.get(
         "/multi-night-visit-maps",
@@ -1095,7 +1144,7 @@ def test_visit_maps_full_mode_both_maps(
     assert call_kwargs["planisphere_only"] is False
     assert call_kwargs["applet_mode"] is False
 
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
 @patch("lsst.ts.logging_and_reporting.web_app.main.get_visits")
@@ -1109,7 +1158,7 @@ def test_visit_maps_no_visits_data(
     mock_observatory_instance = MagicMock()
     mock_observatory.return_value = mock_observatory_instance
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     response = client.get(
         "/multi-night-visit-maps",
@@ -1126,7 +1175,7 @@ def test_visit_maps_no_visits_data(
     assert "interactive" in data
     assert data["interactive"] is None
 
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
 @patch("lsst.ts.logging_and_reporting.web_app.main.get_visits")
@@ -1140,7 +1189,7 @@ def test_visit_maps_read_visits_exception(
     mock_observatory_instance = MagicMock()
     mock_observatory.return_value = mock_observatory_instance
 
-    app.dependency_overrides[get_access_token] = lambda: "dummy-token"
+    app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
 
     response = client.get(
         "/multi-night-visit-maps",
@@ -1154,7 +1203,7 @@ def test_visit_maps_read_visits_exception(
     assert response.status_code == 500
     assert "Database connection error" in response.json()["detail"]
 
-    app.dependency_overrides.pop(get_access_token, None)
+    app.dependency_overrides.pop(rsp_auth, None)
 
 
 def test_expected_exposures_endpoint(monkeypatch):

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -1,12 +1,16 @@
+from datetime import datetime
 from unittest.mock import Mock, patch
 from urllib.parse import quote
 
 import pytest
+from pytz import UTC
+from requests.exceptions import ConnectionError, HTTPError
 
 from lsst.ts.logging_and_reporting.jira import (
     OBS_SYSTEMS_FIELD,
     TIME_LOST_FIELD,
     JiraAdapter,
+    ex,
     get_system_names,
 )
 
@@ -52,74 +56,135 @@ def test_get_system_names(input_data, expected):
 
 
 # ------------------------
-# Tests for get_jira_obs_report (mocked)
+# Tests for get_users_timezone
 # ------------------------
 @patch("lsst.ts.logging_and_reporting.jira.requests.get")
-@patch.dict(
-    "lsst.ts.logging_and_reporting.jira.os.environ",
-    {"JIRA_API_TOKEN": "abc123", "JIRA_API_HOSTNAME": "fake.jira.com"},
-)
+def test_get_users_timezone_success(mock_requests_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"timeZone": "UTC"}
+    mock_requests_get.return_value = mock_response
+
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    tz = adapter.get_users_timezone()
+    assert str(tz) == "UTC"
+    mock_requests_get.assert_called_once_with("https://host/rest/api/latest/myself", headers=adapter.headers)
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_get_users_timezone_failure(mock_requests_get):
+    mock_response = Mock()
+    mock_response.status_code = 403
+    mock_response.text = "Forbidden"
+    mock_requests_get.return_value = mock_response
+
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    with pytest.raises(Exception, match="Error getting user timezone"):
+        adapter.get_users_timezone()
+
+
+# ------------------------
+# Tests for _search
+# ------------------------
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_search_success(mock_requests_get):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"issues": [{"key": "OBS-1", "fields": {}}]}
+    mock_requests_get.return_value = mock_response
+
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    result = adapter._search("project=OBS", fields="key,summary")
+    assert result == [{"key": "OBS-1", "fields": {}}]
+    mock_requests_get.assert_called_once()
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_search_http_error(mock_requests_get):
+    mock_response = Mock()
+    mock_response.status_code = 500
+    mock_response.text = "Server error"
+    mock_response.raise_for_status.side_effect = HTTPError()
+    mock_requests_get.return_value = mock_response
+
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    with pytest.raises(ex.BaseLogrepError, match="Error querying Jira"):
+        adapter._search("project=OBS", fields="key")
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+def test_search_connection_error(mock_requests_get):
+    mock_requests_get.side_effect = ConnectionError("Network down")
+
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    with pytest.raises(ex.BaseLogrepError, match="Error connecting to Jira"):
+        adapter._search("project=OBS", fields="key")
+
+
+# ------------------------
+# Tests for get_obs_issues (mocked)
+# ------------------------
+@pytest.fixture
+def sample_jira_issues():
+    """Return a list of mock Jira issues for testing."""
+    return [
+        {
+            "key": "OBS-999",
+            "fields": {
+                "summary": "Test issue",
+                "updated": "2025-01-01T12:00:00.000+0000",
+                "created": "2025-01-01T11:00:00.000+0000",
+                "status": {"name": "Open"},
+                OBS_SYSTEMS_FIELD: [[{"name": "Simonyi"}]],
+                TIME_LOST_FIELD: 2.0,
+            },
+        },
+        {
+            "key": "OBS-998",
+            "fields": {
+                "summary": "Test issue 2",
+                "updated": "2025-01-01T14:00:00.000+0000",
+                "created": "2025-01-01T13:00:00.000+0000",
+                "status": {"name": "To Do"},
+                OBS_SYSTEMS_FIELD: [[{"name": "AuxTel"}]],
+                TIME_LOST_FIELD: None,
+            },
+        },
+    ]
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
 @patch("lsst.ts.logging_and_reporting.jira.ut.get_utc_datetime_from_dayobs_str")
-def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
-    from datetime import datetime
-
-    from pytz import UTC
-
+def test_get_obs_issues(mock_get_utc, mock_requests_get, sample_jira_issues):
     # Set up mock UTC conversion
     mock_get_utc.side_effect = [
         datetime(2025, 1, 1, 12, 0, tzinfo=UTC),  # for min_dayobs
         datetime(2025, 1, 2, 12, 0, tzinfo=UTC),  # for max_dayobs
     ]
 
-    # Mock first get request to jira /myself to get timezone
-    mock_response_myself_timezone = Mock()
-    mock_response_myself_timezone.status_code = 200
-    mock_response_myself_timezone.json.return_value = {"timeZone": "UTC"}
+    # /myself response for timezone
+    mock_response_myself = Mock()
+    mock_response_myself.status_code = 200
+    mock_response_myself.json.return_value = {"timeZone": "UTC"}
 
-    # Second get request to /search/jql
+    # /search/jql response
     mock_response_search = Mock()
     mock_response_search.status_code = 200
-    mock_response_search.json.return_value = {
-        "issues": [
-            {
-                "key": "OBS-999",
-                "fields": {
-                    "summary": "Test issue",
-                    "updated": "2025-01-01T12:00:00.000Z",
-                    "created": "2025-01-01T11:00:00.000Z",
-                    "status": {"name": "Open"},
-                    OBS_SYSTEMS_FIELD: [[{"name": "Simonyi"}]],
-                    TIME_LOST_FIELD: 2.0,
-                },
-            },
-            {
-                "key": "OBS-998",
-                "fields": {
-                    "summary": "Test issue 2",
-                    "updated": "2025-01-01T14:00:00.000Z",
-                    "created": "2025-01-01T13:00:00.000Z",
-                    "status": {"name": "To Do"},
-                    OBS_SYSTEMS_FIELD: [[{"name": "AuxTel"}]],
-                    TIME_LOST_FIELD: None,
-                },
-            },
-        ]
-    }
+    mock_response_search.json.return_value = {"issues": sample_jira_issues}
 
-    # Setup side effects for each get call
-    mock_requests_get.side_effect = [
-        mock_response_myself_timezone,
-        mock_response_search,
-    ]
+    # Side effect order: first call = /myself, second call = /search/jql
+    mock_requests_get.side_effect = [mock_response_myself, mock_response_search]
 
-    adapter = JiraAdapter(min_dayobs="20250101", max_dayobs="20250102")
-    result = adapter.get_jira_obs_report()
+    adapter = JiraAdapter(jira_token="token", jira_hostname="host")
+    result = adapter.get_obs_issues(min_dayobs="20250101", max_dayobs="20250102")
 
-    # Verify that the Jira JQL query included the excluded statuses
-    called_url = mock_requests_get.call_args.args[0]
+    # Verify the Jira JQL query included the excluded statuses
+    # called_url = mock_requests_get.call_args.args[0]
+    called_url = mock_requests_get.call_args_list[1][0][0]  # second call to /search/jql
     status_exclusions = " ".join(f'AND status != "{s}"' for s in adapter.EXCLUDED_STATUSES)
     assert quote(status_exclusions) in called_url
 
+    # Validate returned issues
     assert isinstance(result, list)
     assert result[0]["key"] == "OBS-999"
     assert result[0]["system"] == ["Simonyi"]
@@ -129,3 +194,100 @@ def test_get_jira_obs_report(mock_get_utc, mock_requests_get):
     assert result[1]["system"] == ["AuxTel"]
     assert result[1]["updated"] == "2025-01-01 14:00:00"
     assert result[1]["time_lost"] is None
+
+
+@pytest.fixture
+def sample_jira_issues_at_dayobs_boundary():
+    """Return a list of mock Jira issues for testing the boundary
+    between dayobs for the returned isNew flag.
+    """
+    return [
+        {
+            "key": "OBS-START",
+            "fields": {
+                "summary": "At start",
+                "updated": "2025-01-01T12:30:00.000+0000",
+                "created": "2025-01-01T12:00:00.000+0000",  # exactly at start
+                "status": {"name": "Open"},
+                OBS_SYSTEMS_FIELD: [[{"name": "Simonyi"}]],
+                TIME_LOST_FIELD: None,
+            },
+        },
+        {
+            "key": "OBS-END",
+            "fields": {
+                "summary": "At end",
+                "updated": "2025-01-01T12:30:00.000+0000",
+                "created": "2025-01-01T13:00:00.000+0000",  # exactly at end
+                "status": {"name": "Open"},
+                OBS_SYSTEMS_FIELD: [[{"name": "AuxTel"}]],
+                TIME_LOST_FIELD: None,
+            },
+        },
+        {
+            "key": "OBS-MID",
+            "fields": {
+                "summary": "In between",
+                "updated": "2025-01-01T12:30:00.000+0000",
+                "created": "2025-01-01T12:30:00.000+0000",  # between start & end
+                "status": {"name": "Open"},
+                OBS_SYSTEMS_FIELD: [[{"name": "AuxTel"}]],
+                TIME_LOST_FIELD: None,
+            },
+        },
+        {
+            "key": "OBS-BEFORE",
+            "fields": {
+                "summary": "Before start",
+                "updated": "2025-01-01T11:59:59.000+0000",
+                "created": "2025-01-01T11:59:59.000+0000",  # before start
+                "status": {"name": "Open"},
+                OBS_SYSTEMS_FIELD: [[{"name": "AuxTel"}]],
+                TIME_LOST_FIELD: None,
+            },
+        },
+    ]
+
+
+@patch("lsst.ts.logging_and_reporting.jira.requests.get")
+@patch("lsst.ts.logging_and_reporting.jira.ut.get_utc_datetime_from_dayobs_str")
+def test_get_obs_issues_is_new_boundaries(
+    mock_get_utc,
+    mock_requests_get,
+    sample_jira_issues_at_dayobs_boundary,
+):
+    from datetime import datetime
+
+    from pytz import UTC
+
+    # Set min/max dayobs
+    start_utc = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+    end_utc = datetime(2025, 1, 1, 13, 0, tzinfo=UTC)
+    mock_get_utc.side_effect = [start_utc, end_utc]
+
+    # Mock /myself returns UTC timezone
+    mock_response_myself = Mock()
+    mock_response_myself.status_code = 200
+    mock_response_myself.json.return_value = {"timeZone": "UTC"}
+
+    mock_response_search = Mock()
+    mock_response_search.status_code = 200
+    mock_response_search.json.return_value = {"issues": sample_jira_issues_at_dayobs_boundary}
+
+    mock_requests_get.side_effect = [mock_response_myself, mock_response_search]
+
+    adapter = JiraAdapter(jira_token="abc123", jira_hostname="fake.jira.com")
+    result = adapter.get_obs_issues(min_dayobs="20250101", max_dayobs="20250101")
+
+    # Check isNew field for boundary conditions
+    assert result[0]["key"] == "OBS-START"
+    assert result[0]["isNew"] is True  # exactly start -> True
+
+    assert result[1]["key"] == "OBS-END"
+    assert result[1]["isNew"] is False  # exactly end -> False
+
+    assert result[2]["key"] == "OBS-MID"
+    assert result[2]["isNew"] is True  # in between -> True
+
+    assert result[3]["key"] == "OBS-BEFORE"
+    assert result[3]["isNew"] is False  # before start -> False

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from lsst.ts.logging_and_reporting.web_app.services import (
@@ -212,15 +214,56 @@ def dummy_tickets():
 class TestGetJiraTickets:
     """Tests for the get_jira_tickets function."""
 
+    def test_get_jira_tickets_passes_correct_args_to_adapter(self, monkeypatch):
+        """Ensure JiraAdapter is instantiated and called with correct
+        arguments.
+        """
+
+        # Mock the adapter class
+        mock_adapter_cls = Mock()
+
+        # Mock the instance returned by the adapter
+        mock_adapter_instance = Mock()
+        mock_adapter_instance.get_obs_issues.return_value = []
+
+        # When JiraAdapter(...) is called, return our mock instance
+        mock_adapter_cls.return_value = mock_adapter_instance
+
+        monkeypatch.setattr(
+            "lsst.ts.logging_and_reporting.web_app.services.jira_service.JiraAdapter",
+            mock_adapter_cls,
+        )
+
+        # Call the function
+        jira_service.get_jira_tickets(
+            20240101,
+            20240102,
+            "LATISS",
+            jira_token="abc",
+            jira_hostname="jira.example.com",
+        )
+
+        # Assert constructor was called correctly
+        mock_adapter_cls.assert_called_once_with(
+            jira_token="abc",
+            jira_hostname="jira.example.com",
+        )
+
+        # Assert method was called correctly
+        mock_adapter_instance.get_obs_issues.assert_called_once_with(
+            min_dayobs=20240101,
+            max_dayobs=20240102,
+        )
+
     def test_get_jira_tickets_returns_empty_list_when_no_tickets(self, monkeypatch):
         """Test that an empty list is returned when no tickets are found."""
 
         class DummyJiraAdapter:
-            def __init__(self, max_dayobs, min_dayobs):
-                self.max_dayobs = max_dayobs
-                self.min_dayobs = min_dayobs
+            def __init__(self, jira_token=None, jira_hostname=None):
+                self.jira_token = jira_token
+                self.jira_hostname = jira_hostname
 
-            def fetch_issues(self):
+            def get_obs_issues(self, min_dayobs, max_dayobs):
                 return []
 
         monkeypatch.setattr(
@@ -232,15 +275,15 @@ class TestGetJiraTickets:
         assert result == []
 
     def test_get_jira_tickets_returns_empty_list_when_fetch_returns_none(self, monkeypatch):
-        """Test that an empty list is returned when
-        fetch_issues returns None."""
+        """Test that an empty list is returned when get_obs_issues
+        returns None.
+        """
 
         class DummyJiraAdapter:
-            def __init__(self, max_dayobs, min_dayobs):
-                self.max_dayobs = max_dayobs
-                self.min_dayobs = min_dayobs
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
 
-            def fetch_issues(self):
+            def get_obs_issues(self, min_dayobs, max_dayobs):
                 return None
 
         monkeypatch.setattr(
@@ -252,15 +295,15 @@ class TestGetJiraTickets:
         assert result == []
 
     def test_get_jira_tickets_filters_by_instrument_included(self, monkeypatch, dummy_tickets):
-        """Test that tickets are filtered to include
-        only specified instruments."""
+        """Test that tickets are filtered to include only specified
+        instruments.
+        """
 
         class DummyJiraAdapter:
-            def __init__(self, max_dayobs, min_dayobs):
-                self.max_dayobs = max_dayobs
-                self.min_dayobs = min_dayobs
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
 
-            def fetch_issues(self):
+            def get_obs_issues(self, min_dayobs, max_dayobs):
                 return dummy_tickets
 
         monkeypatch.setattr(
@@ -271,25 +314,28 @@ class TestGetJiraTickets:
         not_excluding_instruments = (
             jira_service.INSTRUMENTS.keys() - jira_service.INSTRUMENT_EXCLUDE_MAP.keys()
         )
+
         for instrument in not_excluding_instruments:
             result = jira_service.get_jira_tickets(20240101, 20240102, instrument)
+
             included_systems = (
                 instrument,
                 jira_service.INSTRUMENTS[instrument],
             )
+
             for ticket in result:
                 assert any(included in system for included in included_systems for system in ticket["system"])
 
     def test_get_jira_tickets_filters_by_instrument_excluded(self, monkeypatch, dummy_tickets):
-        """Test that tickets are filtered to exclude
-        specified instruments (defined in INSTRUMENT_EXCLUDE_MAP)."""
+        """Test that tickets are filtered to exclude specified instruments
+        (defined in INSTRUMENT_EXCLUDE_MAP).
+        """
 
         class DummyJiraAdapter:
-            def __init__(self, max_dayobs, min_dayobs):
-                self.max_dayobs = max_dayobs
-                self.min_dayobs = min_dayobs
+            def __init__(self, jira_token=None, jira_hostname=None):
+                pass
 
-            def fetch_issues(self):
+            def get_obs_issues(self, min_dayobs, max_dayobs):
                 return dummy_tickets
 
         monkeypatch.setattr(
@@ -299,11 +345,14 @@ class TestGetJiraTickets:
 
         for instrument in jira_service.INSTRUMENT_EXCLUDE_MAP:
             result = jira_service.get_jira_tickets(20240101, 20240102, instrument)
+
             excluded_systems = jira_service.INSTRUMENT_EXCLUDE_MAP[instrument]
+
             match = any(
                 excluded in system
                 for excluded in excluded_systems
                 for ticket in result
                 for system in ticket["system"]
             )
+
             assert not match

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,57 +3,191 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 
-from lsst.ts.logging_and_reporting.utils import get_access_token, make_json_safe, stringify_special_floats
+from lsst.ts.logging_and_reporting.utils import (
+    get_access_token,
+    get_auth_header,
+    get_jira_hostname,
+    make_json_safe,
+    stringify_special_floats,
+)
 
 app = FastAPI()
 
 
-@app.get("/test-access-token")
+@app.get("/test-default-access-token")
 def access_token_endpoint(
     request: Request = None,
-    auth_token: str = Depends(get_access_token),
+    auth_token: str = Depends(get_access_token()),
 ):
     return {"token": auth_token}
 
 
-def test_get_access_token_env_variable(monkeypatch):
+@app.get("/test-jira-access-token")
+def jira_access_token_endpoint(
+    request: Request = None,
+    auth_token: str = Depends(get_access_token("jira")),
+):
+    return {"token": auth_token}
+
+
+# Fetch default (RSP) token via env var
+def test_get_access_token_default_env_variable(monkeypatch):
     monkeypatch.setenv("ACCESS_TOKEN", "env_token")
-    token = get_access_token()
+    dependency = get_access_token()
+    token = dependency()
     assert token == "env_token"
 
 
-def test_get_access_token_rsp_utils():
+# Fetch Jira token via env var
+def test_get_access_token_jira_env_variable(monkeypatch):
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    dependency = get_access_token("jira")
+    token = dependency()
+    assert token == "jira-token"
+
+
+# RSP notebook: Preferred RSPDiscovery path
+def test_get_access_token_rsp_discovery():
+    # Mock hierarchy
+    mock_services = Mock()
+    mock_services.RSPDiscovery.get_token.return_value = "rsp-token"
+
+    mock_rsp = Mock()
+    mock_rsp._services = mock_services
+
     mock_lsst = Mock()
-    mock_lsst.rsp.utils.get_info.return_value = "mocked-token"
+    mock_lsst.rsp = mock_rsp
 
     with patch.dict(
         "sys.modules",
         {
             "lsst": mock_lsst,
-            "lsst.rsp.utils": mock_lsst.rsp.utils,
+            "lsst.rsp": mock_rsp,
+            "lsst.rsp._services": mock_services,
         },
     ):
-        token = get_access_token()
-        assert token == "mocked-token"
+        dependency = get_access_token()
+        token = dependency()
+        assert token == "rsp-token"
+        mock_services.RSPDiscovery.get_token.assert_called_once()
+
+
+# RSP notebook: RSPDiscovery fails --> fallback to env var
+def test_get_access_token_rsp_fallback_to_env(monkeypatch):
+    # Mock hierarchy
+    mock_services = Mock()
+    mock_services.RSPDiscovery.get_token.side_effect = Exception("no token")
+
+    mock_rsp = Mock()
+    mock_rsp._services = mock_services
+
+    mock_lsst = Mock()
+    mock_lsst.rsp = mock_rsp
+
+    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "lsst": mock_lsst,
+            "lsst.rsp": mock_rsp,
+            "lsst.rsp._services": mock_services,
+        },
+    ):
+        dependency = get_access_token()
+        token = dependency()
+        assert token == "env_token"
+
+
+# Fallback to deprecated lsst.utils
+def test_get_access_token_lsst_utils():
+    mock_utils = Mock()
+    mock_utils.get_access_token.return_value = "lsst-token"
+
+    mock_rsp = Mock()
+    mock_rsp.utils = mock_utils
+
+    mock_lsst = Mock()
+    mock_lsst.rsp = mock_rsp
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "lsst": mock_lsst,
+            "lsst.rsp.utils": mock_utils,
+        },
+    ):
+        dependency = get_access_token()
+        token = dependency()
+        assert token == "lsst-token"
 
 
 def test_get_access_token_request_headers(monkeypatch):
     monkeypatch.delenv("ACCESS_TOKEN", raising=False)
     client = TestClient(app)
-    response = client.get("/test-access-token", headers={"Authorization": "Bearer header_token"})
+    response = client.get("/test-default-access-token", headers={"Authorization": "Bearer header_token"})
     assert response.status_code == 200
     assert response.json() == {"token": "header_token"}
 
 
-def test_get_access_token_no_token(monkeypatch):
+def test_get_access_token_no_rsp_token(monkeypatch):
     monkeypatch.delenv("ACCESS_TOKEN", raising=False)
     client = TestClient(app)
-    response = client.get("/test-access-token")
+    response = client.get("/test-default-access-token")
     assert response.status_code == 401
     assert response.json() == {"detail": "RSP authentication token could not be retrieved by any method."}
+
+
+def test_get_access_token_no_jira_token(monkeypatch):
+    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+    client = TestClient(app)
+    response = client.get("/test-jira-access-token")
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Jira authentication token could not be retrieved by any method."}
+
+
+def test_get_auth_header_valid():
+    token = "my-token"
+    header = get_auth_header(token)
+    assert header == {"Authorization": f"Bearer {token}"}
+
+
+def test_get_auth_header_none():
+    try:
+        get_auth_header(None)
+    except ValueError as e:
+        assert str(e) == "Auth token is required"
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_get_auth_header_empty():
+    try:
+        get_auth_header("")
+    except ValueError as e:
+        assert str(e) == "Auth token is required"
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_get_jira_hostname_env(monkeypatch):
+    monkeypatch.setenv("JIRA_API_HOSTNAME", "jira.example.com")
+    hostname = get_jira_hostname()
+    assert hostname == "jira.example.com"
+
+
+def test_get_jira_hostname_missing(monkeypatch):
+    monkeypatch.delenv("JIRA_API_HOSTNAME", raising=False)
+    try:
+        get_jira_hostname()
+    except HTTPException as e:
+        assert e.status_code == 500
+        assert e.detail == "Jira hostname not configured"
+    else:
+        assert False, "Expected HTTPException"
 
 
 def test_stringify_special_floats_nan():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,14 +7,113 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 
 from lsst.ts.logging_and_reporting.utils import (
+    AUTH_SOURCES,
     get_access_token,
     get_auth_header,
     get_jira_hostname,
     make_json_safe,
+    retrieve_access_token,
     stringify_special_floats,
 )
 
 app = FastAPI()
+
+
+def test_retrieve_access_token_env(monkeypatch):
+    config = AUTH_SOURCES["rsp"]
+    monkeypatch.setenv(config["env_var"], "env_token")
+
+    token = retrieve_access_token(config)
+    assert token == "env_token"
+
+
+def test_retrieve_access_token_header(monkeypatch):
+    config = AUTH_SOURCES["rsp"]
+    monkeypatch.delenv(config["env_var"], raising=False)
+
+    class MockRequest:
+        headers = {"Authorization": "Bearer header_token"}
+
+    token = retrieve_access_token(config, request=MockRequest())
+    assert token == "header_token"
+
+
+# RSP notebook: Preferred RSPDiscovery path
+def test_retrieve_access_token_rsp_discovery():
+    config = AUTH_SOURCES["rsp"]
+
+    # Mock hierarchy
+    mock_services = Mock()
+    mock_services.RSPDiscovery.get_token.return_value = "rsp-token"
+
+    mock_rsp = Mock()
+    mock_rsp._services = mock_services
+
+    mock_lsst = Mock()
+    mock_lsst.rsp = mock_rsp
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "lsst": mock_lsst,
+            "lsst.rsp": mock_rsp,
+            "lsst.rsp._services": mock_services,
+        },
+    ):
+        token = retrieve_access_token(config)
+        assert token == "rsp-token"
+        mock_services.RSPDiscovery.get_token.assert_called_once()
+
+
+# RSP notebook: RSPDiscovery fails --> fallback to env var
+def test_retrieve_access_token_rsp_fallback_to_env(monkeypatch):
+    config = AUTH_SOURCES["rsp"]
+
+    mock_services = Mock()
+    mock_services.RSPDiscovery.get_token.side_effect = Exception("no token")
+
+    mock_rsp = Mock()
+    mock_rsp._services = mock_services
+
+    mock_lsst = Mock()
+    mock_lsst.rsp = mock_rsp
+
+    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "lsst": mock_lsst,
+            "lsst.rsp": mock_rsp,
+            "lsst.rsp._services": mock_services,
+        },
+    ):
+        token = retrieve_access_token(config)
+        assert token == "env_token"
+
+
+# Fallback to deprecated lsst.utils
+def test_retrieve_access_token_lsst_utils():
+    config = AUTH_SOURCES["rsp"]
+
+    mock_utils = Mock()
+    mock_utils.get_access_token.return_value = "lsst-token"
+
+    mock_rsp = Mock()
+    mock_rsp.utils = mock_utils
+
+    mock_lsst = Mock()
+    mock_lsst.rsp = mock_rsp
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "lsst": mock_lsst,
+            "lsst.rsp.utils": mock_utils,
+        },
+    ):
+        token = retrieve_access_token(config)
+        assert token == "lsst-token"
 
 
 @app.get("/test-default-access-token")
@@ -47,82 +146,6 @@ def test_get_access_token_jira_env_variable(monkeypatch):
     dependency = get_access_token("jira")
     token = dependency()
     assert token == "jira-token"
-
-
-# RSP notebook: Preferred RSPDiscovery path
-def test_get_access_token_rsp_discovery():
-    # Mock hierarchy
-    mock_services = Mock()
-    mock_services.RSPDiscovery.get_token.return_value = "rsp-token"
-
-    mock_rsp = Mock()
-    mock_rsp._services = mock_services
-
-    mock_lsst = Mock()
-    mock_lsst.rsp = mock_rsp
-
-    with patch.dict(
-        "sys.modules",
-        {
-            "lsst": mock_lsst,
-            "lsst.rsp": mock_rsp,
-            "lsst.rsp._services": mock_services,
-        },
-    ):
-        dependency = get_access_token()
-        token = dependency()
-        assert token == "rsp-token"
-        mock_services.RSPDiscovery.get_token.assert_called_once()
-
-
-# RSP notebook: RSPDiscovery fails --> fallback to env var
-def test_get_access_token_rsp_fallback_to_env(monkeypatch):
-    # Mock hierarchy
-    mock_services = Mock()
-    mock_services.RSPDiscovery.get_token.side_effect = Exception("no token")
-
-    mock_rsp = Mock()
-    mock_rsp._services = mock_services
-
-    mock_lsst = Mock()
-    mock_lsst.rsp = mock_rsp
-
-    monkeypatch.setenv("ACCESS_TOKEN", "env_token")
-
-    with patch.dict(
-        "sys.modules",
-        {
-            "lsst": mock_lsst,
-            "lsst.rsp": mock_rsp,
-            "lsst.rsp._services": mock_services,
-        },
-    ):
-        dependency = get_access_token()
-        token = dependency()
-        assert token == "env_token"
-
-
-# Fallback to deprecated lsst.utils
-def test_get_access_token_lsst_utils():
-    mock_utils = Mock()
-    mock_utils.get_access_token.return_value = "lsst-token"
-
-    mock_rsp = Mock()
-    mock_rsp.utils = mock_utils
-
-    mock_lsst = Mock()
-    mock_lsst.rsp = mock_rsp
-
-    with patch.dict(
-        "sys.modules",
-        {
-            "lsst": mock_lsst,
-            "lsst.rsp.utils": mock_utils,
-        },
-    ):
-        dependency = get_access_token()
-        token = dependency()
-        assert token == "lsst-token"
 
 
 def test_get_access_token_request_headers(monkeypatch):


### PR DESCRIPTION
I have attempted a refactoring of our Jira Adapter, which also includes a refactoring of our authentication utils to accept other tokens. This of course touches lots of things, so this is another big PR–so sorry! (I could potentially separate out the refactor of the auth tokens from the Jira refactor, if that helps?)

Included:
- `get_access_token`
    - Generalised it to accept other tokens
    - Moved `get_access_token` call out of `get_auth_headers` call so the header auth call explicitly requires a token, instead of silently falling back to `get_access_token()`.
    - `lsst.rsp.utils.get_info()` --> `lsst.rsp._services.RSPDiscovery.get_token()` (see comment)
- `JiraAdapter`
    - I didn’t want to touch `SourceAdapter` at this stage, and as that is the base that forces a `dayobs`, I have removed the inheritance. I'm not sure what else from the `SourceAdapter` is necessary to Jira?
    - Now accepts token and hostname.
    - Accepts a `dayobs` range at the function level.
    - Makes use of a reusable `_search` function (will be used for the BLOCKs query, too).
- `BaseLogrepError`
    - I found and fixed a bug when `error_code` is not defined.

This should be merged before OSW-850 (BLOCKs PR).