### PR TITLE
Update version history for v0.13.0

### DIFF
--- a/doc/news/OSW-1257.misc.rst
+++ b/doc/news/OSW-1257.misc.rst
@@ -1,1 +1,0 @@
-Enable fetching all tracebacks from rubin-nights for the Context Feed.

--- a/doc/news/OSW-2058.misc.rst
+++ b/doc/news/OSW-2058.misc.rst
@@ -1,1 +1,0 @@
-Refactor Jira adapter and generalise get_access_token to be token-agnostic.

--- a/doc/news/OSW-2143.misc.rst
+++ b/doc/news/OSW-2143.misc.rst
@@ -1,1 +1,0 @@
-Bump rubin-nights to v0.13.

--- a/doc/news/OSW-850.feature.rst
+++ b/doc/news/OSW-850.feature.rst
@@ -1,1 +1,0 @@
-Add Zephyr/Jira BLOCK services and API endpoint

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -1,3 +1,20 @@
+v0.13.0 (2026-04-16)
+====================
+
+New Features
+------------
+
+- Add Zephyr/Jira BLOCK services and API endpoint (`OSW-850 <https://rubinobs.atlassian.net//browse/OSW-850>`_)
+
+
+Other Changes and Additions
+---------------------------
+
+- Enable fetching all tracebacks from rubin-nights for the Context Feed. (`OSW-1257 <https://rubinobs.atlassian.net//browse/OSW-1257>`_)
+- Refactor Jira adapter and generalise get_access_token to be token-agnostic. (`OSW-2058 <https://rubinobs.atlassian.net//browse/OSW-2058>`_)
+- Bump rubin-nights to v0.13. (`OSW-2143 <https://rubinobs.atlassian.net//browse/OSW-2143>`_)
+
+
 v0.12.1 (2026-03-12)
 ====================
 


### PR DESCRIPTION
the release will also be contained and deployed via v0.13.0-alpha.1 to accommodate the failing conda builds since we wait on `lsst.resources` 