### PR TITLE
OSW-2187: Run visits map process in its own threadpool so it don't block the main thread and other requests can be resolved fine.

### DIFF
--- a/doc/news/OSW-2187.perf.rst
+++ b/doc/news/OSW-2187.perf.rst
@@ -1,0 +1,1 @@
+Run visits map process in its own threadpool so it don't block the main thread and other requests can be resolved fine.

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -5,6 +5,7 @@ from typing import List
 
 from bokeh.embed import json_item
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -343,6 +344,33 @@ async def read_context_feed(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _build_multi_night_visit_map(
+    dayObsStart: int,
+    dayObsEnd: int,
+    instrument: str,
+    planisphereOnly: bool,
+    appletMode: bool,
+    auth_token: str,
+):
+    """Run blocking map generation logic outside the event loop."""
+    visits = get_visits(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
+    v_map = None
+
+    if len(visits):
+        visits = prepare_visit_maps_data(visits)
+        observatory = ModelObservatory(init_load_length=1)
+        v_map, _ = create_visit_skymaps(
+            visits=visits,
+            timezone="UTC",
+            observatory=observatory,
+            planisphere_only=planisphereOnly,
+            applet_mode=appletMode,
+            theme="DARK",
+        )
+
+    return v_map
+
+
 @app.get("/multi-night-visit-maps")
 async def multi_night_visit_maps(
     request: Request,
@@ -383,20 +411,15 @@ async def multi_night_visit_maps(
         f"planisphereOnly: {planisphereOnly}"
     )
     try:
-        visits = get_visits(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
-        v_map = None
-
-        if len(visits):
-            visits = prepare_visit_maps_data(visits)
-            observatory = ModelObservatory(init_load_length=1)
-            v_map, _ = create_visit_skymaps(
-                visits=visits,
-                timezone="UTC",
-                observatory=observatory,
-                planisphere_only=planisphereOnly,
-                applet_mode=appletMode,
-                theme="DARK",
-            )
+        v_map = await run_in_threadpool(
+            _build_multi_night_visit_map,
+            dayObsStart,
+            dayObsEnd,
+            instrument,
+            planisphereOnly,
+            appletMode,
+            auth_token,
+        )
         return {
             "interactive": json_item(v_map) if v_map is not None else None,
         }


### PR DESCRIPTION
This PR makes a performance improvement to the `/multi-night-visit-maps` so it runs in its own threadpool and other concurrent requests don't get blocked.