### PR TITLE
Speed up & Refactor Exposure Log Adapter

### DIFF
--- a/doc/news/OSW-542.perf.rst
+++ b/doc/news/OSW-542.perf.rst
@@ -1,0 +1,1 @@
+Refactor exposure log adapter with goal of speeding up queries.

--- a/python/lsst/ts/logging_and_reporting/exposure_log.py
+++ b/python/lsst/ts/logging_and_reporting/exposure_log.py
@@ -1,0 +1,98 @@
+# This file is part of ts_logging_and_reporting.
+#
+# Developed for Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# #############################################################################
+import logging
+from urllib.parse import urlencode
+
+import lsst.ts.logging_and_reporting.utils as utils
+from lsst.ts.logging_and_reporting.source_adapters import SourceAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ExposurelogAdapter(SourceAdapter):
+    service = "exposurelog"
+    primary_endpoint = "messages?"
+
+    def __init__(
+        self,
+        *,
+        server_url=None,
+        min_dayobs=None,  # Inclusive
+        max_dayobs=None,  # Exclusive
+        limit=None,
+        verbose=False,
+        warning=False,
+        auth_token=None,
+    ):
+        super().__init__(
+            server_url=server_url,
+            max_dayobs=max_dayobs,  # handled here not in the function
+            min_dayobs=min_dayobs,
+            limit=limit,
+            verbose=verbose,
+            warning=warning,
+            auth_token=auth_token,
+        )
+        # The main point of us having a class here is to use SourceAdapter
+        # to handle our authentication, and using protected post/get
+
+    @property
+    def sources(self):
+        return {"Exposure Log API": "/".join([self.server, self.service])}
+
+    def get_messages(
+        self,
+        instrument,
+        group_names=None,
+        observation_reasons=None,
+        observation_types=None,
+        order_by=None,
+        offset=None,
+        limit=None,
+        **optional_params,
+    ):
+        parameters = dict(
+            instrument=instrument,
+            group_names=group_names,
+            observation_reasons=observation_reasons,
+            observation_types=observation_types,
+            order_by=order_by or "-date_added",
+            offset=offset,
+            limit=limit or self.limit,
+        )
+        parameters.update(optional_params)
+
+        if self.min_dayobs:
+            parameters["min_day_obs"] = utils.dayobs_int(self.min_dayobs)
+        # else, we get the most recent messages, up to limit
+        if self.max_dayobs:
+            parameters["max_day_obs"] = utils.dayobs_int(self.max_dayobs)
+        # else, get most recent messages, up to limit, before max dayobs
+
+        endpoint = "/".join([self.sources["Exposure Log API"], self.primary_endpoint])
+        filtered_params = {key: val for key, val in parameters.items() if val is not None}
+        endpoint += urlencode(filtered_params)
+
+        logger.warning(f"{endpoint = }")
+        # TODO: pool paginate
+        messages = self.protected_get(endpoint)
+        return messages

--- a/python/lsst/ts/logging_and_reporting/exposure_log.py
+++ b/python/lsst/ts/logging_and_reporting/exposure_log.py
@@ -43,11 +43,12 @@ class ExposurelogAdapter(SourceAdapter):
         warning=False,
         auth_token=None,
     ):
+        default_record_limit = 2500  # Adapter specific default
         super().__init__(
             server_url=server_url,
             max_dayobs=max_dayobs,  # handled here not in the function
             min_dayobs=min_dayobs,
-            limit=limit,
+            limit=limit or default_record_limit,
             verbose=verbose,
             warning=warning,
             auth_token=auth_token,
@@ -65,6 +66,8 @@ class ExposurelogAdapter(SourceAdapter):
         group_names=None,
         observation_reasons=None,
         observation_types=None,
+        is_human=None,
+        is_valid=None,
         order_by=None,
         offset=None,
         limit=None,
@@ -75,6 +78,8 @@ class ExposurelogAdapter(SourceAdapter):
             group_names=group_names,
             observation_reasons=observation_reasons,
             observation_types=observation_types,
+            is_human=is_human or "true",
+            is_valid=is_valid or "true",
             order_by=order_by or "-date_added",
             offset=offset,
             limit=limit or self.limit,
@@ -92,7 +97,17 @@ class ExposurelogAdapter(SourceAdapter):
         filtered_params = {key: val for key, val in parameters.items() if val is not None}
         endpoint += urlencode(filtered_params)
 
+        # for debugging
         logger.warning(f"{endpoint = }")
         # TODO: pool paginate
-        messages = self.protected_get(endpoint)
+        # Protected get returns a tuple...
+        status, messages, code = self.protected_get(endpoint)
+        if code != 200:
+            logger.warning(f"Error {code} getting exposurelog messages from {endpoint}")
+
+        for entry in messages:
+            # May just have a message.
+            if entry.get("exposure_flag") == "none":
+                entry["exposure_flag"] = "unknown"
+
         return messages

--- a/python/lsst/ts/logging_and_reporting/exposure_log.py
+++ b/python/lsst/ts/logging_and_reporting/exposure_log.py
@@ -63,11 +63,7 @@ class ExposurelogAdapter(SourceAdapter):
     def get_messages(
         self,
         instrument,
-        group_names=None,
-        observation_reasons=None,
-        observation_types=None,
         is_human=None,
-        is_valid=None,
         order_by=None,
         offset=None,
         limit=None,
@@ -75,11 +71,7 @@ class ExposurelogAdapter(SourceAdapter):
     ):
         parameters = dict(
             instrument=instrument,
-            group_names=group_names,
-            observation_reasons=observation_reasons,
-            observation_types=observation_types,
-            is_human=is_human or "true",
-            is_valid=is_valid or "true",
+            is_human=is_human if is_human is not None else "true",
             order_by=order_by or "-date_added",
             offset=offset,
             limit=limit or self.limit,
@@ -97,8 +89,6 @@ class ExposurelogAdapter(SourceAdapter):
         filtered_params = {key: val for key, val in parameters.items() if val is not None}
         endpoint += urlencode(filtered_params)
 
-        # for debugging
-        logger.warning(f"{endpoint = }")
         # TODO: pool paginate
         # Protected get returns a tuple...
         status, messages, code = self.protected_get(endpoint)

--- a/python/lsst/ts/logging_and_reporting/exposure_log.py
+++ b/python/lsst/ts/logging_and_reporting/exposure_log.py
@@ -39,8 +39,6 @@ class ExposurelogAdapter(SourceAdapter):
         min_dayobs=None,  # Inclusive
         max_dayobs=None,  # Exclusive
         limit=None,
-        verbose=False,
-        warning=False,
         auth_token=None,
     ):
         default_record_limit = 2500  # Adapter specific default
@@ -49,8 +47,6 @@ class ExposurelogAdapter(SourceAdapter):
             max_dayobs=max_dayobs,  # handled here not in the function
             min_dayobs=min_dayobs,
             limit=limit or default_record_limit,
-            verbose=verbose,
-            warning=warning,
             auth_token=auth_token,
         )
         # The main point of us having a class here is to use SourceAdapter
@@ -63,28 +59,18 @@ class ExposurelogAdapter(SourceAdapter):
     def get_messages(
         self,
         instrument,
-        group_names=None,
-        observation_reasons=None,
-        observation_types=None,
         is_human=None,
-        is_valid=None,
         order_by=None,
         offset=None,
         limit=None,
-        **optional_params,
     ):
         parameters = dict(
             instrument=instrument,
-            group_names=group_names,
-            observation_reasons=observation_reasons,
-            observation_types=observation_types,
-            is_human=is_human or "true",
-            is_valid=is_valid or "true",
+            is_human=is_human if is_human is not None else "true",
             order_by=order_by or "-date_added",
             offset=offset,
             limit=limit or self.limit,
         )
-        parameters.update(optional_params)
 
         if self.min_dayobs:
             parameters["min_day_obs"] = utils.dayobs_int(self.min_dayobs)
@@ -97,8 +83,6 @@ class ExposurelogAdapter(SourceAdapter):
         filtered_params = {key: val for key, val in parameters.items() if val is not None}
         endpoint += urlencode(filtered_params)
 
-        # for debugging
-        logger.warning(f"{endpoint = }")
         # TODO: pool paginate
         # Protected get returns a tuple...
         status, messages, code = self.protected_get(endpoint)

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -166,7 +166,6 @@ class SourceAdapter(ABC):
 
         if self.verbose and not ok:
             print(f"DEBUG protected_post: FAIL: {result=}")
-
         # when ok=True, result is records (else error message)
         return ok, result, code
 
@@ -184,10 +183,10 @@ class SourceAdapter(ABC):
         # Is this function useful anymore? we are now more separated
         # towards each applet requesting its own data separately,
         # one applet won't hold up another
+        # TODO we should handle retries here
         ok = True
         code = 200
         timeout = timeout or self.timeout
-        print(f"DEBUG protected_get({url=},{timeout=})")
         if self.verbose:
             print(f"DEBUG protected_get({url=},{timeout=})")
         try:

--- a/python/lsst/ts/logging_and_reporting/source_adapters.py
+++ b/python/lsst/ts/logging_and_reporting/source_adapters.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # #############################################################################
 
-import copy
 import datetime as dt
 import itertools
 import traceback
@@ -92,7 +91,7 @@ class SourceAdapter(ABC):
         self.status = dict()
 
         # Store dayobs range
-        self.max_date = ut.dayobs2dt(max_dayobs or "TODAY")
+        self.max_date = ut.dayobs2dt(max_dayobs)
         self.max_dayobs = ut.datetime_to_dayobs(self.max_date)
         if min_dayobs:
             self.min_date = ut.dayobs2dt(min_dayobs)
@@ -182,19 +181,25 @@ class SourceAdapter(ABC):
         RETURN: If the GET works well: ok=True, result=json
         RETURN: If the GET is bad: ok=False, result=error_msg_string
         """
+        # Is this function useful anymore? we are now more separated
+        # towards each applet requesting its own data separately,
+        # one applet won't hold up another
         ok = True
         code = 200
         timeout = timeout or self.timeout
+        print(f"DEBUG protected_get({url=},{timeout=})")
         if self.verbose:
             print(f"DEBUG protected_get({url=},{timeout=})")
         try:
             response = requests.get(url, timeout=timeout, headers=ut.get_auth_header(self.token))
+            # TODO: check if the response is empty and return an empty df
             if self.verbose:
                 print(
                     f"DEBUG protected_get({url=},{ut.get_auth_header(self.token)=},{timeout=}) => "
                     f"{response.status_code=} {response.reason}"
                 )
             response.raise_for_status()
+
         except requests.exceptions.HTTPError as err:
             # Invalid URL?, etc.
             traceback.print_exc()
@@ -204,6 +209,7 @@ class SourceAdapter(ABC):
             result = f"[{self.abbrev}] Error getting data from API at {url}. "
             result += f"{timeout=} {reason=} "
             result += str(err)
+
         except requests.exceptions.ConnectionError as err:
             # No VPN? Broken API?
             traceback.print_exc()
@@ -211,11 +217,13 @@ class SourceAdapter(ABC):
             code = None
             result = f"Error connecting to {url} (with timeout={timeout}). "
             result += str(err)
+
         except Exception as err:
             traceback.print_exc()
             ok = False
             code = None
             result = f"Error getting data from API at {url}. {err}"
+
         else:  # No exception. Could something else be wrong?
             if self.verbose:
                 print(f"DEBUG protected_get: {response.status_code=} {response.reason=}")
@@ -225,6 +233,7 @@ class SourceAdapter(ABC):
 
         if self.verbose and not ok:
             print(f"DEBUG protected_get: FAIL: {result=}")
+
         return ok, result, code
 
     def get_status(self, endpoint=None):
@@ -639,293 +648,3 @@ class NarrativelogAdapter(SourceAdapter):
         return status
 
     # END: class NarrativelogAdapter
-
-
-class ExposurelogAdapter(SourceAdapter):
-    abbrev = "EXP"
-    ignore_fields = ["id"]
-    outfields = {
-        "date_added",
-        "date_invalidated",
-        "day_obs",
-        "exposure_flag",
-        "id",
-        "instrument",
-        "is_human",
-        "is_valid",
-        "level",
-        "message_text",
-        "obs_id",
-        "parent_id",
-        "seq_num",
-        "site_id",
-        "tags",
-        "urls",
-        "user_agent",
-        "user_id",
-    }
-    default_record_limit = 2500  # Adapter specific default
-    service = "exposurelog"
-    endpoints = [
-        "instruments",
-        "exposures",
-        "messages",
-    ]
-    primary_endpoint = "messages"
-    log_dt_field = "date_added"
-
-    def __init__(
-        self,
-        *,
-        server_url=None,
-        min_dayobs=None,  # INCLUSIVE: default=Yesterday
-        max_dayobs=None,  # EXCLUSIVE: default=Today other=YYYY-MM-DD
-        limit=None,
-        verbose=False,
-        warning=False,
-        auth_token=None,
-    ):
-        super().__init__(
-            server_url=server_url,
-            max_dayobs=max_dayobs,
-            min_dayobs=min_dayobs,
-            limit=limit,
-            verbose=verbose,
-            warning=warning,
-            auth_token=auth_token,
-        )
-
-        # status[endpoint] = dict(endpoint_url, number_of_records, error)
-        self.status = dict()
-        self.instruments = dict()  # dict[instrument] = registry
-
-        self.exposures = dict()  # dd[instrument] = [rec, ...]
-        # Load the data (records) we need from relevant endpoints
-        # in dependency order.
-        self.status["instruments"] = self.get_instruments()
-        for instrument in self.instruments.keys():
-            endpoint = f"exposures.{instrument}"
-            self.status[endpoint] = self.get_exposures(instrument)
-        if self.min_date:
-            self.status[self.primary_endpoint] = self.get_records()
-        # Copy exposure_flag from messages to exposures (some to many).
-        self.add_exposure_flag_to_exposures()
-
-    @property
-    def sources(self):
-        return {"Exposure Log API": f"{self.server}/{self.service}/{self.primary_endpoint}"}
-
-    # SIDE-EFFECT: Modifies self.exp_src.exposures in place.429
-    def add_exposure_flag_to_exposures(self):
-        count = 0
-        for instrument in self.exposures.keys():
-            new_recs = list()
-            for rec in self.exposures[instrument]:
-                new_rec = copy.copy(rec)
-                mrec = self.messages_lut.get(rec["obs_id"])
-                if mrec is None:
-                    new_rec["exposure_flag"] = "no flag"
-                else:
-                    count += 1
-                    new_rec["exposure_flag"] = mrec["exposure_flag"]
-                    if self.verbose:
-                        print(f"add_exposure_flag_to_exposures {rec=}")
-                new_recs.append(new_rec)
-            self.exposures[instrument] = new_recs
-        return count
-
-    @property
-    def urls(self):
-        """RETURN flattened list of all URLs."""
-        rurls = [r.get("urls", []) for r in self.records]
-        return set(itertools.chain.from_iterable(rurls))
-
-    def check_endpoints(self, verbose=True):
-        if verbose:
-            msg = "Try to connect ({self.timeout=}) to each endpoint of "
-            msg += f"{self.server}/{self.service} "
-            print(msg)
-
-        url_http_status_code = dict()
-        for ep in self.endpoints:
-            qstr = "?instrument=na" if ep == "exposures" else ""
-            url = f"{self.server}/{self.service}/{ep}{qstr}"
-            ok, result, status_code = self.protected_get(url)
-            url_http_status_code[url] = status_code if ok else "GET error"
-
-        return url_http_status_code, all([v == 200 for v in url_http_status_code.values()])
-
-    def get_instruments(self):
-        url = f"{self.server}/{self.service}/instruments"
-        recs = dict(dummy=[])
-        ok, result, code = self.protected_get(url)
-        if not ok:
-            status = dict(
-                endpoint_url=url,
-                number_of_records=None,
-                error=result,
-            )
-            return status
-
-        recs = result
-        self.instruments = {
-            instrum: int(reg.replace("butler_instruments_", ""))
-            for reg, inst_list in recs.items()
-            for instrum in inst_list
-        }
-        status = dict(
-            endpoint_url=url,
-            number_of_records=len(recs),
-            error=None,
-        )
-        return status
-
-    # RETURNS status: dict[endpoint_url, number_of_records, error]
-    # SIDE-EFFECT: puts records in self.exposures
-    # /exposurelog/exposures
-    # ?registry=2&instrument=LATISS&order_by=-timespan_end&offset=0&limit=50
-    def get_exposures(self, instrument):
-        endpoint = f"{self.server}/{self.service}/exposures"
-        if self.verbose:
-            print(f"Debug get_exposures {endpoint=}")
-
-        registry = self.instruments[instrument]
-        qparams = dict(
-            registry=registry,
-            instrument=instrument,
-            order_by="-timespan_end",
-            offset=0,
-            limit=self.limit,
-        )
-        if self.min_dayobs:
-            qparams["min_day_obs"] = ut.dayobs_int(self.min_dayobs)
-        if self.max_dayobs:
-            qparams["max_day_obs"] = ut.dayobs_int(self.max_dayobs)
-        recs = []
-        while len(recs) <= maximum_record_limit:
-            if self.verbose:
-                print(f"Debug get_exposures qstr: {urlencode(qparams)}")
-            url = f"{endpoint}?{urlencode(qparams)}"
-            ok, result, code = self.protected_get(url)
-            if not ok:  # failure
-                status = dict(
-                    endpoint_url=url,
-                    number_of_records=None,
-                    error=result,
-                )
-                break
-            page = result
-            recs += page
-            status = dict(
-                endpoint_url=url,
-                number_of_records=len(recs),
-                error=None,
-            )
-            if len(page) < self.limit:
-                break  # we defintely got all we asked for
-            qparams["offset"] += len(page)
-        # END: while
-
-        for r in recs:
-            r["exposure_flag"] = None
-
-        self.exposures[instrument] = recs
-        self.exposures_lut = dict()
-        for rec in recs:
-            exp_secs = (
-                dt.datetime.fromisoformat(rec["timespan_end"])
-                - dt.datetime.fromisoformat(rec["timespan_end"])
-            ).total_seconds()
-            rec["exposure_time"] = exp_secs
-            self.exposures_lut[rec["obs_id"]] = rec
-        return status
-
-    def get_records(
-        self,
-        site_ids=None,
-        obs_ids=None,
-        instruments=None,
-        message_text=None,
-        is_human="either",
-        is_valid="true",
-        exposure_flags=None,
-    ):
-        endpoint = f"{self.server}/{self.service}/messages"
-        if self.verbose:
-            print(f"Debug get_records: {endpoint=}")
-
-        qparams = dict(
-            is_human=is_human,
-            is_valid=is_valid,
-            order_by="-day_obs",
-            offset=0,
-            limit=self.limit,
-        )
-        if site_ids:
-            qparams["site_ids"] = site_ids
-        if obs_ids:
-            qparams["obs_ids"] = obs_ids
-        if instruments:
-            qparams["instruments"] = instruments
-        if self.min_dayobs:
-            qparams["min_day_obs"] = ut.dayobs_int(self.min_dayobs)
-        if self.max_dayobs:
-            qparams["max_day_obs"] = ut.dayobs_int(self.max_dayobs)
-        if exposure_flags:
-            qparams["exposure_flags"] = exposure_flags
-
-        qstr = urlencode(qparams)
-        url = f"{endpoint}?{qstr}"
-        recs = []
-        error = None
-        # try:
-        while len(recs) <= maximum_record_limit:
-            if self.verbose:
-                print(f"Debug get_records qstr: {urlencode(qparams)}")
-            url = f"{endpoint}?{urlencode(qparams)}"
-            ok, result, code = self.protected_get(url)
-            if not ok:  # failure
-                status = dict(
-                    endpoint_url=url,
-                    number_of_records=None,
-                    error=result,
-                )
-                return status
-            page = result
-            recs += page
-            status = dict(endpoint_url=url, number_of_records=len(recs), error=None)
-            if len(page) < self.limit:
-                break  # we defintely got all we asked for
-            qparams["offset"] += len(page)
-
-        # Change exposure_flag to avoid confusion with python None type
-        for rec in recs:
-            if rec.get("exposure_flag") == "none":
-                # Does not have a flag, but may have had one in the past
-                # Or may just have a message.
-                rec["exposure_flag"] = "unknown"
-
-        self.records = recs
-        # messages[instrument] => [rec, ...]
-        self.messages = dict()
-        # messages_lut[obs_id] => rec
-        self.messages_lut = {r["obs_id"]: r for r in recs}
-        for instrum in set([r["instrument"] for r in recs]):
-            self.messages[instrum] = [r for r in recs if instrum == r["instrument"]]
-
-        status = dict(
-            endpoint_url=url,
-            number_of_records=len(recs),
-            error=error,
-        )
-        return status
-
-
-# END: class ExposurelogAdapter
-
-
-adapters = [
-    ExposurelogAdapter,
-    NarrativelogAdapter,
-    NightReportAdapter,
-]

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -47,25 +47,17 @@ def get_exposure_flags(
     )
 
     logger.info(f"Fetching exposure flags for instrument: {instrument}")
+    messages = adapter.get_messages(instrument=instrument)
 
-    status = adapter.status.get("messages")
-    logger.debug(f"ExposureLogAdapter status: {status}")
-
-    if status is None or status.get("error") is not None:
-        raise Exception(
-            f"Error getting exposure log messages from {status.get('endpoint_url')}: {status.get('error')}"
-        )
-
-    records = adapter.messages.get(instrument, [])
-    if not records:
+    if not messages:
         verbose and logger.debug("No messages for this instrument.")
         return []
 
     flags = {"questionable", "junk"}
     flagged = [
-        {"obs_id": rec["obs_id"], "exposure_flag": rec["exposure_flag"]}
-        for rec in records
-        if rec.get("exposure_flag") and rec["exposure_flag"] in flags
+        {"obs_id": entry["obs_id"], "exposure_flag": entry["exposure_flag"]}
+        for entry in messages
+        if entry.get("exposure_flag") and entry["exposure_flag"] in flags
     ]
 
     if verbose:
@@ -114,9 +106,10 @@ def get_exposurelog_entries(
     )
 
     # Get records
-    records = adapter.messages.get(instrument, [])
+    # Are we paralellizing this from the front end? call this in pools?
+    messages = adapter.get_messages(instrument=instrument)
 
     if verbose:
-        logger.debug(f"Fetched {len(records)} Exposure Log records for {instrument}")
+        logger.debug(f"Fetched {len(messages)} Exposure Log records for {instrument}")
 
-    return records
+    return messages

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from lsst.ts.logging_and_reporting.source_adapters import ExposurelogAdapter
+from lsst.ts.logging_and_reporting.exposure_log import ExposurelogAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/exposurelog_service.py
@@ -42,7 +42,6 @@ def get_exposure_flags(
         min_dayobs=min_dayobs,
         max_dayobs=max_dayobs,
         limit=limit,
-        verbose=verbose,
         auth_token=auth_token,
     )
 
@@ -101,7 +100,6 @@ def get_exposurelog_entries(
         min_dayobs=min_dayobs,
         max_dayobs=max_dayobs,
         limit=limit,
-        verbose=verbose,
         auth_token=auth_token,
     )
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,88 @@
+from unittest.mock import patch
+
+from lsst.ts.logging_and_reporting.exposure_log import ExposurelogAdapter
+from lsst.ts.logging_and_reporting.utils import Server
+
+
+def test_exposurelog_adapter():
+    initial_params = {
+        "server_url": Server.usdfdev,
+        "min_dayobs": "2024-01-01",
+        "max_dayobs": "2024-02-01",
+        "limit": 345,
+        "verbose": False,
+        "warning": False,
+        "auth_token": "my_auth_token",
+    }
+
+    adapter = ExposurelogAdapter(**initial_params)
+
+    assert adapter.server == Server.usdfdev
+    assert adapter.min_dayobs == "2024-01-01"
+    assert adapter.max_dayobs == "2024-02-01"
+    assert adapter.limit == 345
+    assert adapter.verbose is False
+    assert adapter.warning is False
+    assert adapter.token == "my_auth_token"
+    assert "https://usdf-rsp-dev.slac.stanford.edu/exposurelog" in adapter.sources.values()
+
+
+@patch("lsst.ts.logging_and_reporting.exposure_log.ExposurelogAdapter.protected_get")
+def test_get_messages(mock_get):
+    mock_get.return_value = (True, [], 200)
+    initial_params = {
+        "server_url": Server.usdfdev,
+        "min_dayobs": "2024-01-01",
+        "max_dayobs": "2024-02-01",
+        "auth_token": "my_auth_token",
+    }
+
+    adapter = ExposurelogAdapter(**initial_params)
+    adapter.get_messages(
+        instrument="LATISS",
+        is_human="true",
+        order_by="-day_obs",
+        offset=10,
+        limit=5,
+        is_valid="false",
+    )
+    args, kwargs = mock_get.call_args
+    actual_url = args[0]
+
+    assert actual_url.startswith("https://usdf-rsp-dev.slac.stanford.edu/exposurelog/messages?")
+    assert "instrument=LATISS" in actual_url
+    assert "min_day_obs=20240101" in actual_url
+    assert "max_day_obs=20240201" in actual_url
+    assert "is_human=true" in actual_url
+    assert "is_valid=false" in actual_url
+    assert "order_by=-day_obs" in actual_url
+    assert "offset=10" in actual_url
+    assert "limit=5" in actual_url
+    assert "instrument=LATISS" in actual_url
+    assert "limit=5" in actual_url
+
+
+@patch("lsst.ts.logging_and_reporting.exposure_log.ExposurelogAdapter.protected_get")
+def test_get_messages_defaults(mock_get):
+    mock_get.return_value = (True, [], 200)
+    adapter = ExposurelogAdapter(
+        server_url=Server.usdfdev,
+        min_dayobs="2024-01-01",
+        max_dayobs="2024-02-01",
+        auth_token="my_auth_token",
+    )
+
+    # Use defaults by only providing the required 'instrument' argument
+    adapter.get_messages(instrument="LATISS")
+
+    args, _ = mock_get.call_args
+    actual_url = args[0]
+
+    assert "instrument=LATISS" in actual_url
+
+    assert "is_human=true" in actual_url
+    assert "order_by=-date_added" in actual_url
+    assert "limit=2500" in actual_url
+
+    # Verify that things not provided (and not defaulted) are not here
+    assert "offset=" not in actual_url

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch
+
+from lsst.ts.logging_and_reporting.exposure_log import ExposurelogAdapter
+from lsst.ts.logging_and_reporting.utils import Server
+
+
+def test_exposurelog_adapter():
+    initial_params = {
+        "server_url": Server.usdfdev,
+        "min_dayobs": "2024-01-01",
+        "max_dayobs": "2024-02-01",
+        "limit": 345,
+        "auth_token": "my_auth_token",
+    }
+
+    adapter = ExposurelogAdapter(**initial_params)
+
+    assert adapter.server == Server.usdfdev
+    assert adapter.min_dayobs == "2024-01-01"
+    assert adapter.max_dayobs == "2024-02-01"
+    assert adapter.limit == 345
+    assert adapter.token == "my_auth_token"
+    assert "https://usdf-rsp-dev.slac.stanford.edu/exposurelog" in adapter.sources.values()
+
+
+@patch("lsst.ts.logging_and_reporting.exposure_log.ExposurelogAdapter.protected_get")
+def test_get_messages(mock_get):
+    mock_get.return_value = (True, [], 200)
+    initial_params = {
+        "server_url": Server.usdfdev,
+        "min_dayobs": "2024-01-01",
+        "max_dayobs": "2024-02-01",
+        "auth_token": "my_auth_token",
+    }
+
+    adapter = ExposurelogAdapter(**initial_params)
+    adapter.get_messages(
+        instrument="LATISS",
+        is_human="true",
+        order_by="-day_obs",
+        offset=10,
+        limit=5,
+    )
+    args, kwargs = mock_get.call_args
+    actual_url = args[0]
+
+    assert actual_url.startswith("https://usdf-rsp-dev.slac.stanford.edu/exposurelog/messages?")
+    assert "instrument=LATISS" in actual_url
+    assert "min_day_obs=20240101" in actual_url
+    assert "max_day_obs=20240201" in actual_url
+    assert "is_human=true" in actual_url
+    assert "order_by=-day_obs" in actual_url
+    assert "offset=10" in actual_url
+    assert "limit=5" in actual_url
+    assert "instrument=LATISS" in actual_url
+    assert "limit=5" in actual_url
+
+
+@patch("lsst.ts.logging_and_reporting.exposure_log.ExposurelogAdapter.protected_get")
+def test_get_messages_defaults(mock_get):
+    mock_get.return_value = (True, [], 200)
+    adapter = ExposurelogAdapter(
+        server_url=Server.usdfdev,
+        min_dayobs="2024-01-01",
+        max_dayobs="2024-02-01",
+        auth_token="my_auth_token",
+    )
+
+    # Use defaults by only providing the required 'instrument' argument
+    adapter.get_messages(instrument="LATISS")
+
+    args, _ = mock_get.call_args
+    actual_url = args[0]
+
+    assert "instrument=LATISS" in actual_url
+
+    assert "is_human=true" in actual_url
+    assert "order_by=-date_added" in actual_url
+    assert "limit=2500" in actual_url
+
+    # Verify that things not provided (and not defaulted) are not here
+    assert "offset=" not in actual_url

--- a/tests/test_all_sources.py
+++ b/tests/test_all_sources.py
@@ -20,11 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # #############################################################################
 
-# EXAMPLE:
-#   pytest tests/test_all_sources.py
-# Use FactoryBoy https://factoryboy.readthedocs.io/
-# to generate faux source records
-
 import datetime as dt
 import unittest
 


### PR DESCRIPTION
When the ticket to speed up the exposure log adapter was originally written we were still using eager fetching of the data. I removed that previously, and here I add only requesting the specific data that we need from exposure log. (Added instrument and other filtering to the query) 
I refactored the rest of the class to include only functionality that fits our current assumptions of being called from our endpoints. 

If we need to further speed up the response we could request data in pools, especially since the source supports data returned limits and offsets, allowing us to easily break up the time periods and merge the data after.

While testing and comparing this work to what is active in develop branch, I found that the different sorting I use (-date_added vs -day_obs) showed different comments on 20260328. Seba helped me find out this is because exposures can have multiple comments associated with each.
This ticket should serve as our place to talk about and prioritize accommodating that:
https://rubinobs.atlassian.net/browse/OSW-2257