### PR TITLE
OSW-1557 Time Accounting: factor in dome time changes introduced in rubin-nights v0.10.0

### DIFF
--- a/doc/news/OSW-1557.feature.rst
+++ b/doc/news/OSW-1557.feature.rst
@@ -1,0 +1,1 @@
+Simply frontend dome times and time accounting calculations by doing them in the backend and utilising the aggregations introduced in rubin-nights > 0.10

--- a/python/lsst/ts/logging_and_reporting/utils.py
+++ b/python/lsst/ts/logging_and_reporting/utils.py
@@ -68,6 +68,28 @@ def date_hr_min(iso_dt_str):
     return str(dt.datetime.fromisoformat(iso_dt_str))[:16]
 
 
+def current_dayobs_utc(now_utc: pd.Timestamp | dt.datetime) -> int:
+    """Compute the active dayobs for a UTC timestamp.
+
+    Parameters
+    ----------
+    now_utc : pandas.Timestamp or datetime.datetime
+        UTC timestamp to convert.
+
+    Returns
+    -------
+    int
+        Dayobs in ``YYYYMMDD`` form.
+
+    Notes
+    -----
+    A dayobs runs from noon UTC to noon UTC, so subtracting 12 hours
+    and taking the date gives the correct dayobs for any time in that
+    window.
+    """
+    return int((now_utc - dt.timedelta(hours=12)).strftime("%Y%m%d"))
+
+
 def fallback_parameters(day_obs, number_of_days, period, verbose, warning):
     """Given parameters from Times Square, return usable versions of
     all parameters.  If the provide parameters are not usable, return

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -36,6 +36,7 @@ from fastapi.responses import JSONResponse
 from lsst.ts.logging_and_reporting.exceptions import BaseLogrepError, ConsdbQueryError
 from lsst.ts.logging_and_reporting.utils import (
     build_block_response,
+    current_dayobs_utc,
     get_access_token,
     get_jira_hostname,
     make_json_safe,
@@ -54,7 +55,6 @@ from .services.narrativelog_service import get_messages
 from .services.nightreport_service import get_night_reports
 from .services.rubin_nights_service import (
     _compute_closed_hours,
-    _current_dayobs_utc,
     get_context_feed,
     get_obs_status,
     get_open_close_dome,
@@ -173,7 +173,7 @@ async def read_exposures(
                         {"night_hours": "max", "open_hours": "sum", "sunset12": "first", "sunrise12": "first"}
                     )
                     now_utc = pd.Timestamp.now(tz="UTC")
-                    current_dayobs = _current_dayobs_utc(now_utc)
+                    current_dayobs = current_dayobs_utc(now_utc)
                     open_dome_totals["closed_hours"] = open_dome_totals.apply(
                         lambda row: _compute_closed_hours(row, current_dayobs, now_utc),
                         axis=1,

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -119,7 +119,6 @@ async def read_exposures_from_mock_data(request: Request, dayObsStart: int, dayO
 
 @app.get("/exposures")
 async def read_exposures(
-    request: Request,
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
@@ -129,49 +128,44 @@ async def read_exposures(
     try:
         exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)
         on_sky_exposures = [exp for exp in exposures if exp.get("can_see_sky")]
-        total_exposure_time = sum(exposure["exp_time"] for exposure in exposures)
-        total_on_sky_exposure_time = sum(exp["exp_time"] for exp in on_sky_exposures)
+        total_exposure_time = sum(exp.get("exp_time") or 0 for exp in exposures)
+        total_on_sky_exposure_time = sum(exp.get("exp_time") or 0 for exp in on_sky_exposures)
 
-        open_dome_times = get_open_close_dome(dayObsStart, dayObsEnd, instrument, auth_token)
+        open_dome_times_records, open_dome_hours_records, open_dome_error = [], {}, None
+        try:
+            open_dome_times = get_open_close_dome(dayObsStart, dayObsEnd, instrument, auth_token)
+            logger.debug(f"Open/close dome times from rubin_nights: {open_dome_times}")
 
-        exposures_df = get_time_accounting(
-            dayObsStart,
-            dayObsEnd,
-            instrument,
-            exposures,
-            auth_token,
-        )
+            if open_dome_times is not None and not open_dome_times.empty:
+                open_dome_times_records = make_json_safe(open_dome_times.to_dict(orient="records"))
 
-        if not exposures_df.empty:
-            exposures_dict = exposures_df[
-                [
-                    "exposure_id",
-                    "exposure_name",
-                    "exp_time",
-                    "img_type",
-                    "observation_reason",
-                    "science_program",
-                    "target_name",
-                    "can_see_sky",
-                    "band",
-                    "obs_start",
-                    "physical_filter",
-                    "day_obs",
-                    "seq_num",
-                    "obs_end",
-                    "overhead",
-                    "zero_point_median",
-                    "visit_id",
-                    "overhead",
-                    "pixel_scale_median",
-                    "psf_sigma_median",
-                    "visit_gap",
-                ]
-            ].to_dict(orient="records")
+                try:
+                    open_dome_totals = open_dome_times.groupby("day_obs").agg(
+                        {"night_hours": "max", "open_hours": "sum"}
+                    )
+                    open_dome_hours_records = make_json_safe(open_dome_totals.to_dict(orient="index"))
+                except Exception as e:
+                    logger.error(f"Error aggregating open/close dome times: {e}", exc_info=True)
+                    open_dome_hours_records = None
+                    open_dome_error = "Failed to aggregate dome open hours"
 
-            exposures_safe_dict = make_json_safe(exposures_dict)
+        except Exception as e:
+            logger.error(
+                f"Error getting open/close dome times from rubin_nights through EFD: {e}", exc_info=True
+            )
+            open_dome_times_records = None
+            open_dome_hours_records = None
+            open_dome_error = "Failed to retrieve dome open/close times"
 
-            exposures = jsonable_encoder(exposures_safe_dict)
+        # TODO: return time accounting sums by day_obs?
+        night_time_on_sky_sums, time_accounting_error = None, None
+        try:
+            night_time_on_sky_sums = get_time_accounting(
+                dayObsStart, dayObsEnd, instrument, exposures, auth_token
+            )
+        except Exception as e:
+            logger.error(f"Error computing time accounting in /exposures: {e}", exc_info=True)
+            time_accounting_error = "Failed to compute night time accounting"
 
         return {
             "exposures": exposures,
@@ -179,7 +173,11 @@ async def read_exposures(
             "sum_exposure_time": total_exposure_time,
             "on_sky_exposures_count": len(on_sky_exposures),
             "total_on_sky_exposure_time": total_on_sky_exposure_time,
-            "open_dome_times": make_json_safe(open_dome_times.to_dict(orient="records")),
+            "open_dome_times": open_dome_times_records,
+            "day_obs_open_dome_hours": open_dome_hours_records,
+            "open_dome_error": open_dome_error,
+            "night_on_sky_time_accounting": night_time_on_sky_sums,
+            "time_accounting_error": time_accounting_error,
         }
 
     except ConsdbQueryError as ce:

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -25,6 +25,7 @@ import logging
 import re
 from typing import List
 
+import pandas as pd
 from bokeh.embed import json_item
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
@@ -52,6 +53,9 @@ from .services.jira_service import get_block_ticket_summaries, get_jira_tickets
 from .services.narrativelog_service import get_messages
 from .services.nightreport_service import get_night_reports
 from .services.rubin_nights_service import (
+    _compute_closed_hours,
+    _current_dayobs_utc,
+    _elapsed_night_hours,
     get_context_feed,
     get_obs_status,
     get_open_close_dome,
@@ -134,14 +138,23 @@ async def read_exposures(
         open_dome_times_records, open_dome_hours_records, open_dome_error = [], {}, None
         try:
             open_dome_times = get_open_close_dome(dayObsStart, dayObsEnd, instrument, auth_token)
-            logger.debug(f"Open/close dome times from rubin_nights: {open_dome_times}")
 
             if open_dome_times is not None and not open_dome_times.empty:
                 open_dome_times_records = make_json_safe(open_dome_times.to_dict(orient="records"))
 
                 try:
                     open_dome_totals = open_dome_times.groupby("day_obs").agg(
-                        {"night_hours": "max", "open_hours": "sum"}
+                        {"night_hours": "max", "open_hours": "sum", "sunset12": "first", "sunrise12": "first"}
+                    )
+                    now_utc = pd.Timestamp.now(tz="UTC")
+                    current_dayobs = _current_dayobs_utc(now_utc)
+                    open_dome_totals["closed_hours"] = open_dome_totals.apply(
+                        lambda row: _compute_closed_hours(row, current_dayobs, now_utc),
+                        axis=1,
+                    )
+                    open_dome_totals["elapsed_night_hours"] = open_dome_totals.apply(
+                        lambda row: _elapsed_night_hours(row, current_dayobs, now_utc),
+                        axis=1,
                     )
                     open_dome_hours_records = make_json_safe(open_dome_totals.to_dict(orient="index"))
                 except Exception as e:

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -55,7 +55,6 @@ from .services.nightreport_service import get_night_reports
 from .services.rubin_nights_service import (
     _compute_closed_hours,
     _current_dayobs_utc,
-    _elapsed_night_hours,
     get_context_feed,
     get_obs_status,
     get_open_close_dome,
@@ -152,10 +151,6 @@ async def read_exposures(
                         lambda row: _compute_closed_hours(row, current_dayobs, now_utc),
                         axis=1,
                     )
-                    open_dome_totals["elapsed_night_hours"] = open_dome_totals.apply(
-                        lambda row: _elapsed_night_hours(row, current_dayobs, now_utc),
-                        axis=1,
-                    )
                     open_dome_hours_records = make_json_safe(open_dome_totals.to_dict(orient="index"))
                 except Exception as e:
                     logger.error(f"Error aggregating open/close dome times: {e}", exc_info=True)
@@ -170,7 +165,6 @@ async def read_exposures(
             open_dome_hours_records = None
             open_dome_error = "Failed to retrieve dome open/close times"
 
-        # TODO: return time accounting sums by day_obs?
         night_time_on_sky_sums, time_accounting_error = None, None
         try:
             night_time_on_sky_sums = get_time_accounting(

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -23,7 +23,7 @@
 import base64
 import logging
 import re
-from typing import List
+from typing import Any, List
 
 import pandas as pd
 from bokeh.embed import json_item
@@ -126,7 +126,34 @@ async def read_exposures(
     dayObsEnd: int,
     instrument: str,
     auth_token: str = Depends(rsp_auth),
-):
+) -> dict[str, Any]:
+    """Return exposures and derived night-summary metrics.
+
+    Parameters
+    ----------
+    dayObsStart : int
+        Inclusive lower bound of the requested dayobs range.
+    dayObsEnd : int
+        Exclusive upper bound of the requested dayobs range.
+    instrument : str
+        Instrument name used for the ConsDB exposure query.
+    auth_token : str, optional
+        Authentication token injected from the request context.
+
+    Returns
+    -------
+    dict[str, Any]
+        JSON-serialisable response containing raw exposure records,
+        exposure totals, dome-open summaries, and twilight-windowed
+        time-accounting metrics.
+
+    Raises
+    ------
+    fastapi.HTTPException
+        Raised with status 502 if the underlying ConsDB query fails, or
+        500 for any other unhandled error. Dome-open and time-accounting
+        sub-query failures are reported in the response payload instead.
+    """
     logger.info(f"Getting exposures for start: {dayObsStart}, end: {dayObsEnd} and instrument: {instrument}")
     try:
         exposures = get_exposures(dayObsStart, dayObsEnd, instrument, auth_token=auth_token)

--- a/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from lsst.ts.logging_and_reporting.almanac import Almanac
 
@@ -8,7 +9,19 @@ logger = logging.getLogger(__name__)
 
 
 def _as_utc_datetime(timestamp: str) -> datetime:
-    """Parse an almanac timestamp string as a timezone-aware UTC datetime."""
+    """Parse an almanac timestamp as a timezone-aware UTC datetime.
+
+    Parameters
+    ----------
+    timestamp : str
+        ISO-format timestamp string returned by the almanac adapter.
+
+    Returns
+    -------
+    datetime.datetime
+        Timestamp converted to UTC. Naive inputs are assumed to already
+        represent UTC.
+    """
     dt = datetime.fromisoformat(timestamp)
     if dt.tzinfo is None:
         return dt.replace(tzinfo=UTC)
@@ -21,8 +34,28 @@ def _compute_elapsed_twilight_hours(
     twilight_morning_12deg: str,
     now_utc: datetime | None = None,
 ) -> float:
-    """Compute completed twilight hours for a night.
+    """Compute completed nautical-twilight hours for a night.
 
+    Parameters
+    ----------
+    night_hours : float
+        Total duration of the night, in hours.
+    twilight_evening_12deg : str
+        Evening 12-degree twilight timestamp in ISO format.
+    twilight_morning_12deg : str
+        Morning 12-degree twilight timestamp in ISO format.
+    now_utc : datetime.datetime or None, optional
+        Reference UTC timestamp. If not provided, the current UTC time
+        is used.
+
+    Returns
+    -------
+    float
+        Completed twilight hours, clamped to the inclusive range
+        ``[0, night_hours]``.
+
+    Notes
+    -----
     Future nights contribute 0 hours, completed nights contribute the full
     ``night_hours``, and an in-progress night contributes the elapsed time
     since evening nautical twilight.
@@ -40,7 +73,30 @@ def _compute_elapsed_twilight_hours(
     return min(elapsed_hours, night_hours)
 
 
-def get_almanac(dayobs_start: int, dayobs_end: int) -> list:
+def get_almanac(dayobs_start: int, dayobs_end: int) -> list[dict[str, Any]]:
+    """Return almanac records for a dayobs range.
+
+    Parameters
+    ----------
+    dayobs_start : int
+        Inclusive lower bound of the requested dayobs range.
+    dayobs_end : int
+        Exclusive upper bound of the requested dayobs range.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Almanac records containing twilight, moon, and night-duration
+        fields, plus ``elapsed_twilight_hours`` for each returned
+        night.
+
+    Notes
+    -----
+    The returned records are labeled by the dayobs of the morning
+    twilight boundary, so querying ``[dayobs_start, dayobs_end)`` yields
+    records whose ``dayobs`` values span ``dayobs_start + 1`` through
+    ``dayobs_end``.
+    """
     logger.info(f"Getting almanac for start: {dayobs_start}, end: {dayobs_end}")
     try:
         # adding one day to the start and end dates as the Almanac adapter

--- a/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/almanac_service.py
@@ -1,10 +1,43 @@
 import logging
 import traceback
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from lsst.ts.logging_and_reporting.almanac import Almanac
 
 logger = logging.getLogger(__name__)
+
+
+def _as_utc_datetime(timestamp: str) -> datetime:
+    """Parse an almanac timestamp string as a timezone-aware UTC datetime."""
+    dt = datetime.fromisoformat(timestamp)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _compute_elapsed_twilight_hours(
+    night_hours: float,
+    twilight_evening_12deg: str,
+    twilight_morning_12deg: str,
+    now_utc: datetime | None = None,
+) -> float:
+    """Compute completed twilight hours for a night.
+
+    Future nights contribute 0 hours, completed nights contribute the full
+    ``night_hours``, and an in-progress night contributes the elapsed time
+    since evening nautical twilight.
+    """
+    now_utc = now_utc or datetime.now(UTC)
+    evening_twilight_utc = _as_utc_datetime(twilight_evening_12deg)
+    morning_twilight_utc = _as_utc_datetime(twilight_morning_12deg)
+
+    if now_utc <= evening_twilight_utc:
+        return 0.0
+    if now_utc >= morning_twilight_utc:
+        return night_hours
+
+    elapsed_hours = (now_utc - evening_twilight_utc).total_seconds() / 3600
+    return min(elapsed_hours, night_hours)
 
 
 def get_almanac(dayobs_start: int, dayobs_end: int) -> list:
@@ -20,14 +53,16 @@ def get_almanac(dayobs_start: int, dayobs_end: int) -> list:
             dayobs = int(current.strftime("%Y%m%d"))
             almanac = Almanac(min_dayobs=dayobs_start, max_dayobs=dayobs)
             night_events = almanac.as_dict[0]
+            twilight_evening_12deg = night_events["Evening Nautical Twilight"]
+            twilight_morning_12deg = night_events["Morning Nautical Twilight"]
             almanac_info.append(
                 {
                     "dayobs": dayobs,
                     "night_hours": almanac.night_hours,
                     "twilight_evening_18deg": night_events["Evening Astronomical Twilight"],
                     "twilight_morning_18deg": night_events["Morning Astronomical Twilight"],
-                    "twilight_evening_12deg": night_events["Evening Nautical Twilight"],
-                    "twilight_morning_12deg": night_events["Morning Nautical Twilight"],
+                    "twilight_evening_12deg": twilight_evening_12deg,
+                    "twilight_morning_12deg": twilight_morning_12deg,
                     "twilight_evening_6deg": night_events["Evening Civil Twilight"],
                     "twilight_morning_6deg": night_events["Morning Civil Twilight"],
                     "twilight_evening_0deg": night_events["Sun Set"],
@@ -35,6 +70,11 @@ def get_almanac(dayobs_start: int, dayobs_end: int) -> list:
                     "moon_rise_time": night_events["Moon Rise"],
                     "moon_set_time": night_events["Moon Set"],
                     "moon_illumination": night_events["Moon Illumination"],
+                    "elapsed_twilight_hours": _compute_elapsed_twilight_hours(
+                        almanac.night_hours,
+                        twilight_evening_12deg,
+                        twilight_morning_12deg,
+                    ),
                 }
             )
             current += timedelta(days=1)

--- a/python/lsst/ts/logging_and_reporting/web_app/services/consdb_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/consdb_service.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -26,8 +27,8 @@ def get_exposures(
     dayobs_end: int,
     telescope: str,
     auth_token: str = None,
-) -> dict:
-    exposures = {}
+) -> list[dict[str, Any]]:
+    exposures = []
     logger.info(f"Getting exposures for start: {dayobs_start}, end: {dayobs_end} and telescope: {telescope}")
     cons_db = ConsdbAdapter(
         server_url=nd_utils.Server.get_url(),

--- a/python/lsst/ts/logging_and_reporting/web_app/services/consdb_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/consdb_service.py
@@ -12,11 +12,28 @@ from lsst.ts.logging_and_reporting.utils import stringify_special_floats
 logger = logging.getLogger(__name__)
 
 
-def convert_row(row):
+def convert_row(row: Any) -> dict[str, Any]:
+    """Convert a table row to a plain Python dictionary.
+
+    Parameters
+    ----------
+    row : object
+        Mapping-like row object, typically from an Astropy table.
+
+    Returns
+    -------
+    dict[str, Any]
+        Row contents with NumPy scalar values converted to native Python
+        scalar types.
+    """
     return {key: (row[key].item() if isinstance(row[key], np.generic) else row[key]) for key in row.keys()}
 
 
-def get_mock_exposures(dayobs_start: int, dayobs_end: int, telescope: str) -> list:
+def get_mock_exposures(
+    dayobs_start: int,
+    dayobs_end: int,
+    telescope: str,
+) -> list[dict[str, Any]]:
     exposure_table = Table.read("data/exposures-lsstcam0413.ecsv")
     exposures = [convert_row(exp) for exp in exposure_table]
     return exposures
@@ -26,8 +43,26 @@ def get_exposures(
     dayobs_start: int,
     dayobs_end: int,
     telescope: str,
-    auth_token: str = None,
+    auth_token: str | None = None,
 ) -> list[dict[str, Any]]:
+    """Query exposure records from ConsDB for a dayobs range.
+
+    Parameters
+    ----------
+    dayobs_start : int
+        Inclusive lower bound of the requested dayobs range.
+    dayobs_end : int
+        Exclusive upper bound of the requested dayobs range.
+    telescope : str
+        ConsDB instrument suffix, for example ``"lsstcam"``.
+    auth_token : str or None, optional
+        Authentication token used when connecting to ConsDB.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Exposure records returned by ConsDB, ordered by ``seq_num``.
+    """
     exposures = []
     logger.info(f"Getting exposures for start: {dayobs_start}, end: {dayobs_end} and telescope: {telescope}")
     cons_db = ConsdbAdapter(

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -56,6 +56,7 @@ OBSERVATORY_STATES = {
 }
 OBS_STATUS_AVAILABLE_DAYOBS = 20260225
 MILLISECONDS_IN_AN_HOUR = 3600000
+SECONDS_IN_AN_HOUR = 3600
 
 
 def dayobs_to_noon_utc(dayobs: int) -> Time:
@@ -69,15 +70,102 @@ def dayobs_to_noon_utc(dayobs: int) -> Time:
     )
 
 
+def _twilight_windows_by_dayobs(almanac_info: list[dict]) -> dict[int, tuple[int, int]]:
+    """Map each visit's day_obs to its 12-degree twilight window, in ms.
+
+    The almanac service labels a night's record with the dayobs of its
+    *morning* twilight boundary -- one calendar day after the day_obs that
+    visits taken during that night are tagged with -- so each record is
+    mapped back to ``dayobs - 1`` (using calendar-safe dayobs arithmetic)
+    to match it against ``visits.day_obs``.
+    """
+    windows = {}
+    for night in almanac_info:
+        visit_dayobs = add_or_subtract_dayobs_days(night["dayobs"], -1)
+        windows[visit_dayobs] = (
+            almanac_to_unix_ms(night["twilight_evening_12deg"]),
+            almanac_to_unix_ms(night["twilight_morning_12deg"]),
+        )
+    return windows
+
+
+def _obs_start_tai_to_utc_ms(obs_start: pd.Series) -> pd.Series:
+    """Convert a Series of TAI ISO-format
+    obs_start strings to Unix ms (UTC)."""
+    result = pd.Series(np.nan, index=obs_start.index, dtype="float64")
+    valid = obs_start.notna()
+    if valid.any():
+        tai_times = Time(obs_start[valid].astype(str).tolist(), format="isot", scale="tai")
+        result.loc[valid] = tai_times.utc.unix * 1000
+    return result
+
+
+def _compute_filter_changed(visits_sorted: pd.DataFrame) -> pd.Series:
+    """Flag each visit as a filter/band change relative to the
+    immediately preceding visit. Expects `visits_sorted` to already be
+    ordered by obs_start.
+    """
+    band_prev = visits_sorted["band"].shift(1)
+
+    # NaN-aware inequality: a value changing to/from NaN also counts
+    # as a change, but NaN-to-NaN does not.
+    band_changed = (visits_sorted["band"] != band_prev) & ~(visits_sorted["band"].isna() & band_prev.isna())
+
+    band_changed.iloc[0] = False  # no prior visit to compare the first entry against
+
+    return band_changed
+
+
+def _sum_on_sky_within_twilight(
+    visits: pd.DataFrame,
+    almanac_info: list[dict],
+) -> dict[str, float]:
+    """Sum overhead/visit_gap (in hours) for visits with can_see_sky True
+    whose obs_start (TAI) falls within that night's 12-degree twilight
+    window, split by whether the filter/band changed from the previous
+    visit. overhead and visit_gap are stored in seconds; the sums are
+    converted to hours once, at the end, to avoid compounding rounding
+    error across many per-row divisions.
+    """
+    visits_sorted = visits.sort_values("obs_start")
+
+    windows = _twilight_windows_by_dayobs(almanac_info)
+    window_start_ms = (
+        visits_sorted["day_obs"].map(lambda d: windows.get(d, (np.nan, np.nan))[0]).astype(float)
+    )
+    window_end_ms = visits_sorted["day_obs"].map(lambda d: windows.get(d, (np.nan, np.nan))[1]).astype(float)
+
+    obs_start_utc_ms = _obs_start_tai_to_utc_ms(visits_sorted["obs_start"])
+
+    in_twilight = (obs_start_utc_ms >= window_start_ms) & (obs_start_utc_ms <= window_end_ms)
+    base_mask = visits_sorted["can_see_sky"].fillna(False).astype(bool) & in_twilight
+
+    filter_changed = _compute_filter_changed(visits_sorted)
+    with_change_mask = base_mask & filter_changed
+    without_change_mask = base_mask & ~filter_changed
+
+    overhead = visits_sorted["overhead"].fillna(0)
+    visit_gap = visits_sorted["visit_gap"].fillna(0)
+
+    sums_sec = {
+        "sum_overhead_with_filter_change": float(overhead[with_change_mask].sum()),
+        "sum_overhead_without_filter_change": float(overhead[without_change_mask].sum()),
+        "sum_visit_gap_with_filter_change": float(visit_gap[with_change_mask].sum()),
+        "sum_visit_gap_without_filter_change": float(visit_gap[without_change_mask].sum()),
+    }
+
+    return {key: round(float(total / SECONDS_IN_AN_HOUR), 2) for key, total in sums_sec.items()}
+
+
 def get_time_accounting(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
     exposures: list,
     auth_token: str = None,
-) -> pd.DataFrame:
+) -> dict[str, float]:
     """
-    Retrieve and process time accounting data for a given instrument
+    Compute twilight-windowed time-accounting sums for a given instrument
     and range of observation days.
     This function takes a list of exposures and augments them with
     visit information, calculates model slew times, and computes
@@ -99,49 +187,246 @@ def get_time_accounting(
 
     Returns
     -------
-    pd.DataFrame
-        A DataFrame containing the processed visit
-        and overhead information.
-        Returns an empty DataFrame if no exposures
-        are provided or if an error occurs.
+    dict[str, float]
+        The four overhead/visit_gap sums, in hours, for visits where
+        ``can_see_sky`` is true and ``obs_start`` falls within the
+        12-degree twilight interval, split by whether the filter/band
+        changed from the previous visit.
     """
     logger.info(
         f"Getting time accounting data for dayObsStart: {dayObsStart}, "
         f"dayObsEnd: {dayObsEnd} and instrument: {instrument}"
     )
-    try:
-        if len(exposures) == 0:
-            return pd.DataFrame()
 
-        # Get connections to rubin_nights services
-        clients = get_clients(auth_token=auth_token)
+    if len(exposures) == 0:
+        return {
+            "sum_overhead_with_filter_change": 0.0,
+            "sum_overhead_without_filter_change": 0.0,
+            "sum_visit_gap_with_filter_change": 0.0,
+            "sum_visit_gap_without_filter_change": 0.0,
+        }
 
-        exposures_df = pd.DataFrame(exposures)
-        visits = rn_aug.augment_visits(exposures_df, "lsstcam", skip_rs_columns=True)
+    exposures_df = pd.DataFrame(exposures)
 
-        visits, _ = rn_sch.add_model_slew_times(
-            visits, clients["efd"], model_settle=WAIT_BEFORE_SLEW + SETTLE, dome_crawl=False
+    # Get connections to rubin_nights services
+    clients = get_clients(auth_token=auth_token)
+
+    visits = rn_aug.augment_visits(exposures_df, "lsstcam", skip_rs_columns=True)
+
+    visits, _ = rn_sch.add_model_slew_times(
+        visits, clients["efd"], model_settle=WAIT_BEFORE_SLEW + SETTLE, dome_crawl=False
+    )
+
+    valid_overhead = np.min(
+        [
+            np.where(np.isnan(visits.slew_model.values), 0, visits.slew_model.values) + MAX_SCATTER,
+            visits.visit_gap.values,
+        ],
+        axis=0,
+    )
+    visits["overhead"] = valid_overhead
+
+    visits = visits.replace([np.inf, -np.inf], np.nan)
+    visits = visits.where(pd.notnull(visits), None)
+
+    # Get almanac data for twilight boundaries, to enable night-only metrics.
+    # Fetched here -- before the NaN->None JSON-safety pass below -- so the
+    # twilight sums can be computed with plain vectorised float comparisons.
+    almanac_dayobs_end = add_or_subtract_dayobs_days(dayObsEnd, 1)
+    almanac_info = get_almanac(dayObsStart, almanac_dayobs_end)
+
+    twilight_sums = _sum_on_sky_within_twilight(visits, almanac_info)
+
+    return twilight_sums
+
+
+_DOME_OPEN_COLUMNS = [
+    "day_obs",
+    "open_time",
+    "close_time",
+    "dome_hours",
+    "sunset12",
+    "sunrise12",
+    "night_hours",
+    "open_hours",
+]
+_ZERO_DURATION_COLUMNS = ("dome_hours", "open_hours")
+_NULL_TIME_COLUMNS = ("open_time", "close_time")
+_ALMANAC_TWILIGHT_COLUMN_MAP = {
+    "sunset12": "twilight_evening_12deg",
+    "sunrise12": "twilight_morning_12deg",
+}
+
+
+def _dayobs_range(start_dayobs: int, end_dayobs_exclusive: int) -> list[int]:
+    """List of dayobs ints from start_dayobs up to
+    (excluding) end_dayobs_exclusive."""
+    days = []
+    current = start_dayobs
+    while current < end_dayobs_exclusive:
+        days.append(current)
+        current = add_or_subtract_dayobs_days(current, 1)
+    return days
+
+
+def _almanac_by_visit_dayobs(almanac_info: list[dict]) -> dict[int, dict]:
+    """Map each almanac record to the visit day_obs it covers.
+
+    Mirrors the mapping already established for time accounting: the
+    almanac service labels a night's record with the dayobs of its
+    *morning* twilight -- one calendar day after the day_obs visits
+    taken that night are tagged with.
+    """
+    return {add_or_subtract_dayobs_days(record["dayobs"], -1): record for record in almanac_info}
+
+
+def _build_missing_dayobs_row(
+    dayobs: int,
+    columns: pd.Index,
+    almanac_record: dict | None,
+) -> dict[str, Any]:
+    """Construct a placeholder row for a dayobs missing from dome_open.
+
+    Mirrors the shape of a real "dome closed all night" row (e.g.
+    dome_hours/open_hours: 0, open_time/close_time: null), except
+    sunset12/sunrise12/night_hours are backfilled from the matching
+    almanac record rather than measured, since no real dome event
+    exists to derive them from.
+    """
+    row: dict[str, Any] = {}
+    for col in columns:
+        if col == "day_obs":
+            row[col] = int(dayobs)
+        elif col in _ZERO_DURATION_COLUMNS:
+            row[col] = 0.0
+        elif col in _NULL_TIME_COLUMNS:
+            row[col] = pd.NaT
+        elif col == "night_hours":
+            row[col] = almanac_record.get("night_hours") if almanac_record else np.nan
+        elif col in _ALMANAC_TWILIGHT_COLUMN_MAP:
+            almanac_key = _ALMANAC_TWILIGHT_COLUMN_MAP[col]
+            value = almanac_record.get(almanac_key) if almanac_record else None
+            row[col] = pd.Timestamp(value) if value else pd.NaT
+        else:
+            logger.warning(
+                f"sanitize_dome_open_close: no fill rule for column '{col}' "
+                f"on synthesized row for missing dayobs {dayobs}; defaulting to NaN"
+            )
+            row[col] = np.nan
+    return row
+
+
+def sanitize_dome_open_close(
+    dome_open: pd.DataFrame,
+    dayObsStart: int,
+    dayObsEnd: int,
+) -> pd.DataFrame:
+    """Restrict and complete dome open/close records for the requested
+    night range.
+
+    Three corrections are applied:
+
+    1. Normalize schema: dome_open is reindexed onto _DOME_OPEN_COLUMNS
+       so every row -- real or synthesized -- always carries the full
+       expected field set. The upstream response has been observed to
+       sometimes omit columns entirely (not just leave them null) on a
+       given call; without this step, that omission would silently
+       propagate into every row, including any synthesized placeholder
+       rows built in step 3, which would otherwise inherit the same gap.
+    2. Trim: get_dome_open_close is queried over
+       [noon(dayObsStart), noon(dayObsEnd)], which spans nights
+       dayObsStart through (dayObsEnd - 1) inclusive -- dayObsEnd itself
+       is only the boundary timestamp. It has been observed to
+       occasionally return a trailing extra dayObs beyond that
+       boundary; this trims it back to exactly the requested range.
+    3. Fill: any dayobs in the requested range with no entry at all in
+       the trimmed result gets a synthesized placeholder row -- twilight
+       times and night_hours from get_almanac, 0 for duration columns,
+       NaT for open/close time columns. See _build_missing_dayobs_row.
+
+    Parameters
+    ----------
+    dome_open : pd.DataFrame
+        Raw dome open/close records, expected to carry day_obs (YYYYMMDD
+        ints) as either a column or the index.
+    dayObsStart : int
+        Start of the requested dayObs range (inclusive).
+    dayObsEnd : int
+        End of the requested dayObs range (the boundary timestamp;
+        the last valid night is dayObsEnd - 1).
+
+    Returns
+    -------
+    pd.DataFrame
+        Exactly one entry per night in [dayObsStart, dayObsEnd - 1],
+        with a consistent schema of _DOME_OPEN_COLUMNS, sorted by
+        day_obs. Returns the input unchanged if day_obs can't be
+        located as either a column or the index name.
+    """
+    if dome_open is None:
+        dome_open = pd.DataFrame()
+
+    # Normalise day_obs to a plain column regardless of how it arrived.
+    if not dome_open.empty and "day_obs" not in dome_open.columns:
+        if dome_open.index.name == "day_obs":
+            dome_open = dome_open.reset_index()
+        else:
+            logger.warning(
+                "sanitize_dome_open_close: could not locate 'day_obs' as a "
+                "column or index name; returning data unfiltered"
+            )
+            return dome_open
+
+    if not dome_open.empty:
+        missing_columns = [c for c in _DOME_OPEN_COLUMNS if c not in dome_open.columns]
+        if missing_columns:
+            logger.warning(
+                f"sanitize_dome_open_close: dome_open response is missing "
+                f"expected column(s) {missing_columns}; filling with NaN. "
+                f"This likely indicates an upstream schema gap worth "
+                f"investigating, distinct from a missing-dayobs gap."
+            )
+        # Reindex onto the canonical column set: adds any missing columns
+        # as NaN, drops/ignores anything unexpected, and fixes column
+        # order -- guaranteeing every row that follows has the full schema.
+        dome_open = dome_open.reindex(columns=_DOME_OPEN_COLUMNS)
+
+    last_valid_dayobs = add_or_subtract_dayobs_days(dayObsEnd, -1)
+    requested_dayobs = _dayobs_range(dayObsStart, dayObsEnd)
+
+    if dome_open.empty:
+        trimmed = pd.DataFrame(columns=_DOME_OPEN_COLUMNS)
+        present_dayobs: set[int] = set()
+    else:
+        in_range = (dome_open["day_obs"] >= dayObsStart) & (dome_open["day_obs"] <= last_valid_dayobs)
+        dropped = int((~in_range).sum())
+        if dropped:
+            logger.info(
+                f"sanitize_dome_open_close: dropping {dropped} row(s) outside "
+                f"[{dayObsStart}, {last_valid_dayobs}]"
+            )
+        trimmed = dome_open.loc[in_range]
+        present_dayobs = set(trimmed["day_obs"])
+
+    missing_dayobs = [d for d in requested_dayobs if d not in present_dayobs]
+
+    if missing_dayobs:
+        logger.info(
+            f"sanitize_dome_open_close: synthesizing placeholder rows for "
+            f"dayobs missing from dome data: {missing_dayobs}"
+        )
+        almanac_info = get_almanac(dayObsStart, dayObsEnd)
+        almanac_by_dayobs = _almanac_by_visit_dayobs(almanac_info)
+
+        new_rows = [
+            _build_missing_dayobs_row(d, _DOME_OPEN_COLUMNS, almanac_by_dayobs.get(d)) for d in missing_dayobs
+        ]
+        trimmed = pd.concat(
+            [trimmed, pd.DataFrame(new_rows, columns=_DOME_OPEN_COLUMNS)],
+            ignore_index=True,
         )
 
-        valid_overhead = np.min(
-            [
-                np.where(np.isnan(visits.slew_model.values), 0, visits.slew_model.values) + MAX_SCATTER,
-                visits.visit_gap.values,
-            ],
-            axis=0,
-        )
-        visits["overhead"] = valid_overhead
-
-        visits = visits.replace([np.inf, -np.inf], np.nan)
-        visits = visits.where(pd.notnull(visits), None)
-
-        return visits
-
-    except Exception as e:
-        logger.error(
-            f"Error in getting time accounting data from rubin_nights through EFD: {e}", exc_info=True
-        )
-        return pd.DataFrame()
+    return trimmed.sort_values("day_obs").reset_index(drop=True)
 
 
 def get_open_close_dome(
@@ -175,17 +460,13 @@ def get_open_close_dome(
         f"Getting open/close dome times from rubin-nights for dayObsStart: {dayObsStart}, "
         f"dayObsEnd: {dayObsEnd} and instrument: {instrument}"
     )
-    try:
-        # Get connections to rubin_nights services
-        clients = get_clients(auth_token=auth_token)
+    # Get connections to rubin_nights services
+    clients = get_clients(auth_token=auth_token)
 
-        day_min = dayobs_to_noon_utc(dayObsStart)
-        day_max = dayobs_to_noon_utc(dayObsEnd)
-        dome_open = get_dome_open_close(day_min, day_max, clients["efd"])
-        return dome_open
-    except Exception as e:
-        logger.error(f"Error getting open/close dome times from rubin_nights through EFD: {e}", exc_info=True)
-        return pd.DataFrame()
+    day_min = dayobs_to_noon_utc(dayObsStart)
+    day_max = dayobs_to_noon_utc(dayObsEnd)
+    dome_open = get_dome_open_close(day_min, day_max, clients["efd"])
+    return sanitize_dome_open_close(dome_open, dayObsStart, dayObsEnd)
 
 
 def get_context_feed(

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -60,8 +60,18 @@ SECONDS_IN_AN_HOUR = 3600
 
 
 def dayobs_to_noon_utc(dayobs: int) -> Time:
-    """Convert a YYYYMMDD dayobs to its noon UTC boundary,
-    in the format required for rubin-nights query inputs.
+    """Convert a dayobs integer to its noon-UTC boundary.
+
+    Parameters
+    ----------
+    dayobs : int
+        Observation day in ``YYYYMMDD`` form.
+
+    Returns
+    -------
+    astropy.time.Time
+        Noon UTC timestamp for the supplied dayobs, formatted for
+        Rubin Nights query APIs.
     """
     return Time(
         f"{rn_dayobs.day_obs_int_to_str(dayobs)}T12:00:00",
@@ -71,8 +81,21 @@ def dayobs_to_noon_utc(dayobs: int) -> Time:
 
 
 def _twilight_windows_by_dayobs(almanac_info: list[dict]) -> dict[int, tuple[int, int]]:
-    """Map each visit's day_obs to its 12-degree twilight window, in ms.
+    """Map each visit dayobs to its 12-degree twilight window.
 
+    Parameters
+    ----------
+    almanac_info : list[dict]
+        Almanac records keyed by the Rubin Nights dayobs convention.
+
+    Returns
+    -------
+    dict[int, tuple[int, int]]
+        Mapping from visit ``day_obs`` to ``(evening_twilight_ms,
+        morning_twilight_ms)`` in Unix milliseconds.
+
+    Notes
+    -----
     The almanac service labels a night's record with the dayobs of its
     *morning* twilight boundary -- one calendar day after the day_obs that
     visits taken during that night are tagged with -- so each record is
@@ -90,8 +113,19 @@ def _twilight_windows_by_dayobs(almanac_info: list[dict]) -> dict[int, tuple[int
 
 
 def _obs_start_tai_to_utc_ms(obs_start: pd.Series) -> pd.Series:
-    """Convert a Series of TAI ISO-format
-    obs_start strings to Unix ms (UTC)."""
+    """Convert TAI observation-start timestamps to Unix milliseconds.
+
+    Parameters
+    ----------
+    obs_start : pandas.Series
+        Observation-start timestamps in TAI ISO-string form.
+
+    Returns
+    -------
+    pandas.Series
+        UTC Unix timestamps in milliseconds, preserving the input index.
+        Missing input values are returned as ``NaN``.
+    """
     result = pd.Series(np.nan, index=obs_start.index, dtype="float64")
     valid = obs_start.notna()
     if valid.any():
@@ -101,17 +135,24 @@ def _obs_start_tai_to_utc_ms(obs_start: pd.Series) -> pd.Series:
 
 
 def _compute_filter_changed(visits_sorted: pd.DataFrame) -> pd.Series:
-    """Flag each visit as a filter/band change relative to the
-    immediately preceding visit. Expects `visits_sorted` to already be
-    ordered by obs_start.
+    """Flag visits whose filter differs from the previous visit.
+
+    Parameters
+    ----------
+    visits_sorted : pandas.DataFrame
+        Visit table already sorted by ``obs_start``.
+
+    Returns
+    -------
+    pandas.Series
+        Boolean mask indicating whether each visit changed filter/band
+        relative to the immediately preceding visit.
     """
     band_prev = visits_sorted["band"].shift(1)
 
-    # NaN-aware inequality: a value changing to/from NaN also counts
-    # as a change, but NaN-to-NaN does not.
     band_changed = (visits_sorted["band"] != band_prev) & ~(visits_sorted["band"].isna() & band_prev.isna())
 
-    band_changed.iloc[0] = False  # no prior visit to compare the first entry against
+    band_changed.iloc[0] = False
 
     return band_changed
 
@@ -120,10 +161,29 @@ def _sum_on_sky_within_twilight(
     visits: pd.DataFrame,
     almanac_info: list[dict],
 ) -> dict[str, float]:
-    """Sum overhead/visit_gap (in hours) for visits with can_see_sky True
-    whose obs_start (TAI) falls within that night's 12-degree twilight
-    window, split by whether the filter/band changed from the previous
-    visit. overhead and visit_gap are stored in seconds; the sums are
+    """Summarize on-sky overhead and visit-gap time within twilight.
+
+    Parameters
+    ----------
+    visits : pandas.DataFrame
+        Visit records containing ``day_obs``, ``obs_start``,
+        ``can_see_sky``, ``band``, ``overhead``, and ``visit_gap``.
+    almanac_info : list[dict]
+        Almanac records covering the nights represented by ``visits``.
+
+    Returns
+    -------
+    dict[str, float]
+        Four hour-valued sums split by whether the filter changed from
+        the previous visit:
+        ``sum_overhead_with_filter_change``,
+        ``sum_overhead_without_filter_change``,
+        ``sum_visit_gap_with_filter_change``, and
+        ``sum_visit_gap_without_filter_change``.
+
+    Notes
+    -----
+    ``overhead`` and ``visit_gap`` are stored in seconds. The sums are
     converted to hours once, at the end, to avoid compounding rounding
     error across many per-row divisions.
     """
@@ -161,27 +221,23 @@ def get_time_accounting(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    exposures: list,
-    auth_token: str = None,
+    exposures: list[dict[str, Any]],
+    auth_token: str | None = None,
 ) -> dict[str, float]:
-    """
-    Compute twilight-windowed time-accounting sums for a given instrument
-    and range of observation days.
-    This function takes a list of exposures and augments them with
-    visit information, calculates model slew times, and computes
-    valid overheads for each visit.
+    """Compute twilight-windowed time-accounting sums for exposures.
 
     Parameters
     ----------
     dayObsStart : int
-        The starting dayObs (observation day) for which to retrieve data.
+        Inclusive lower bound of the requested dayobs range.
     dayObsEnd : int
-        The ending dayObs (observation day) for which to retrieve data.
+        Exclusive upper bound of the requested dayobs range.
     instrument : str
-        The name of the instrument for which to retrieve time accounting data.
-    exposures : list
-        A list of exposure dictionaries or objects to be processed.
-    auth_token : str, optional
+        Instrument name. Currently logged but not used to choose the
+        augmentation or query logic in this function.
+    exposures : list[dict[str, Any]]
+        Exposure records from the ``/exposures`` query.
+    auth_token : str or None, optional
         Authentication token used when connecting to Rubin Observatory
         services.
 
@@ -208,7 +264,6 @@ def get_time_accounting(
 
     exposures_df = pd.DataFrame(exposures)
 
-    # Get connections to rubin_nights services
     clients = get_clients(auth_token=auth_token)
 
     visits = rn_aug.augment_visits(exposures_df, "lsstcam", skip_rs_columns=True)
@@ -230,8 +285,6 @@ def get_time_accounting(
     visits = visits.where(pd.notnull(visits), None)
 
     # Get almanac data for twilight boundaries, to enable night-only metrics.
-    # Fetched here -- before the NaN->None JSON-safety pass below -- so the
-    # twilight sums can be computed with plain vectorised float comparisons.
     almanac_dayobs_end = add_or_subtract_dayobs_days(dayObsEnd, 1)
     almanac_info = get_almanac(dayObsStart, almanac_dayobs_end)
 
@@ -241,8 +294,20 @@ def get_time_accounting(
 
 
 def _current_dayobs_utc(now_utc: pd.Timestamp | datetime) -> int:
-    """Compute the current dayobs from a UTC timestamp.
+    """Compute the active dayobs for a UTC timestamp.
 
+    Parameters
+    ----------
+    now_utc : pandas.Timestamp or datetime.datetime
+        UTC timestamp to convert.
+
+    Returns
+    -------
+    int
+        Dayobs in ``YYYYMMDD`` form.
+
+    Notes
+    -----
     A dayobs runs from noon UTC to noon UTC, so subtracting 12 hours
     and taking the date gives the correct dayobs for any time in that
     window.
@@ -253,26 +318,39 @@ def _current_dayobs_utc(now_utc: pd.Timestamp | datetime) -> int:
 def _compute_closed_hours(
     row: pd.Series,
     current_dayobs: int,
-    now_utc: datetime,
+    now_utc: pd.Timestamp | datetime,
 ) -> float:
-    """Compute closed_hours for a single dome row.
+    """Compute closed dome hours for a single aggregated dome row.
 
+    Parameters
+    ----------
+    row : pandas.Series
+        Dome-open row or grouped row containing ``night_hours``,
+        ``open_hours``, ``sunset12``, and ``sunrise12``. ``day_obs`` may
+        be either a column or the Series name.
+    current_dayobs : int
+        Current dayobs in ``YYYYMMDD`` form.
+    now_utc : pandas.Timestamp or datetime.datetime
+        Current UTC timestamp used to detect an in-progress night.
+
+    Returns
+    -------
+    float
+        Closed hours for the night represented by ``row``.
+
+    Notes
+    -----
     The input row may come either from the raw dome-open dataframe
     (where ``day_obs`` is a column) or from a dataframe aggregated by
     ``day_obs`` (where it becomes the Series name / index key).
 
-    Three cases:
-
-    Past night (day_obs < current_dayobs):
-        closed_hours = night_hours - open_hours.
-
-    Current night in progress, dome has not opened (open_hours == 0):
-        closed_hours = elapsed time since evening twilight (sunset12).
-
-    Current night in progress, dome has opened (open_hours > 0):
-        closed_hours = night_hours - open_hours..
-        `rubin-nights` calculates open_hours based on elapsed times
-        when the dome has opened but haven't closed yet.
+    For completed nights, closed hours are ``night_hours - open_hours``.
+    For the current night, the intended meaning is "closed so far", so
+    the value is computed against elapsed twilight time:
+    ``max(0, elapsed_twilight_hours - open_hours)``. This uses the
+    elapsed ``open_hours`` reported by Rubin Nights once the dome has
+    opened, but still returns elapsed twilight time before the first
+    opening when ``open_hours == 0``.
     """
     day_obs = row.get("day_obs", row.name)
     sunset12_utc = pd.to_datetime(row["sunset12"], utc=True)
@@ -290,54 +368,44 @@ def _compute_closed_hours(
 
     elapsed_hours = (now_utc - sunset12_utc).total_seconds() / 3600
 
-    if row["open_hours"] == 0:
-        return elapsed_hours
-    else:
-        return row["night_hours"] - row["open_hours"]
+    return max(0.0, elapsed_hours - row["open_hours"])
 
 
 def get_open_close_dome(
     dayObsStart: int,
     dayObsEnd: int,
     instrument: str,
-    auth_token: str = None,
+    auth_token: str | None = None,
 ) -> pd.DataFrame:
-    """Retrieve dome open/close records for the requested night range.
+    """Retrieve dome open/close records for a dayobs range.
 
     Parameters
     ----------
     dayObsStart : int
-        The starting observation day (as an integer, e.g., YYYYMMDD).
+        Inclusive lower bound of the requested dayobs range.
     dayObsEnd : int
-        The exclusive upper boundary observation day (as an integer,
-        e.g., YYYYMMDD). The last returned night is ``dayObsEnd - 1``.
+        Exclusive upper bound of the requested dayobs range.
     instrument : str
-        The instrument name. Currently logged but not used to filter
-        the dome query.
-    auth_token : str, optional
+        Instrument name. Currently logged but not used to filter the
+        dome query.
+    auth_token : str or None, optional
         Authentication token used when connecting to Rubin Observatory
         services.
 
     Returns
     -------
     pd.DataFrame
-        Dome open/close records sanitized to one row per requested
-        ``day_obs`` in ``[dayObsStart, dayObsEnd - 1]``, with the
-        canonical schema defined by ``_DOME_OPEN_COLUMNS``.
+        Raw Rubin Nights dome-open records for the query window.
     """
     logger.info(
         f"Getting open/close dome times from rubin-nights for dayObsStart: {dayObsStart}, "
         f"dayObsEnd: {dayObsEnd} and instrument: {instrument}"
     )
-    # Get connections to rubin_nights services
     clients = get_clients(auth_token=auth_token)
 
     day_min = dayobs_to_noon_utc(dayObsStart)
     day_max = dayobs_to_noon_utc(dayObsEnd)
     dome_open = get_dome_open_close(day_min, day_max, clients["efd"])
-
-    if "day_obs" not in dome_open.columns and dome_open.index.name == "day_obs":
-        dome_open = dome_open.reset_index()
 
     return dome_open
 

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -22,7 +22,7 @@
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any
 
 import numpy as np
@@ -36,7 +36,10 @@ from rubin_nights.observatory_status import get_dome_open_close
 from rubin_nights.scriptqueue import get_consolidated_messages
 
 from lsst.ts.logging_and_reporting.exceptions import ConsdbQueryError
-from lsst.ts.logging_and_reporting.utils import add_or_subtract_dayobs_days, stringify_special_floats
+from lsst.ts.logging_and_reporting.utils import (
+    add_or_subtract_dayobs_days,
+    stringify_special_floats,
+)
 
 from .almanac_service import get_almanac
 
@@ -291,28 +294,6 @@ def get_time_accounting(
     twilight_sums = _sum_on_sky_within_twilight(visits, almanac_info)
 
     return twilight_sums
-
-
-def _current_dayobs_utc(now_utc: pd.Timestamp | datetime) -> int:
-    """Compute the active dayobs for a UTC timestamp.
-
-    Parameters
-    ----------
-    now_utc : pandas.Timestamp or datetime.datetime
-        UTC timestamp to convert.
-
-    Returns
-    -------
-    int
-        Dayobs in ``YYYYMMDD`` form.
-
-    Notes
-    -----
-    A dayobs runs from noon UTC to noon UTC, so subtracting 12 hours
-    and taking the date gives the correct dayobs for any time in that
-    window.
-    """
-    return int((now_utc - timedelta(hours=12)).strftime("%Y%m%d"))
 
 
 def _compute_closed_hours(

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -296,51 +296,6 @@ def _compute_closed_hours(
         return row["night_hours"] - row["open_hours"]
 
 
-def _elapsed_night_hours(
-    row: pd.Series,
-    current_dayobs: int,
-    now_utc: pd.Timestamp,
-) -> float:
-    """Hours elapsed since evening twilight, capped at night_hours.
-
-    For past nights, returns night_hours (the night is complete).
-    For the current night in progress, returns time elapsed since
-    sunset12 -- this is the correct baseline for fault time, since
-    exposure_time, overhead, and weather_loss all only reflect what
-    has happened so far, not the full projected night.
-
-    Parameters
-    ----------
-    row : pd.Series
-        Aggregated per-night dome row with sunset12, sunrise12,
-        night_hours, and day_obs.
-    current_dayobs : int
-        The dayobs currently in progress.
-    now_utc : pd.Timestamp
-        Current UTC time, timezone-aware.
-
-    Returns
-    -------
-    float
-        Elapsed night hours to use as the fault time baseline.
-    """
-    day_obs = row.get("day_obs", row.name)
-    sunset12_utc = pd.to_datetime(row["sunset12"], utc=True)
-    sunrise12_utc = pd.to_datetime(row["sunrise12"], utc=True)
-
-    night_in_progress = (
-        day_obs == current_dayobs
-        and pd.notna(sunset12_utc)
-        and pd.notna(sunrise12_utc)
-        and sunset12_utc <= now_utc <= sunrise12_utc
-    )
-
-    if not night_in_progress:
-        return row["night_hours"]
-
-    return (now_utc - sunset12_utc).total_seconds() / 3600
-
-
 def get_open_close_dome(
     dayObsStart: int,
     dayObsEnd: int,

--- a/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/services/rubin_nights_service.py
@@ -22,7 +22,7 @@
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import numpy as np
@@ -240,193 +240,105 @@ def get_time_accounting(
     return twilight_sums
 
 
-_DOME_OPEN_COLUMNS = [
-    "day_obs",
-    "open_time",
-    "close_time",
-    "dome_hours",
-    "sunset12",
-    "sunrise12",
-    "night_hours",
-    "open_hours",
-]
-_ZERO_DURATION_COLUMNS = ("dome_hours", "open_hours")
-_NULL_TIME_COLUMNS = ("open_time", "close_time")
-_ALMANAC_TWILIGHT_COLUMN_MAP = {
-    "sunset12": "twilight_evening_12deg",
-    "sunrise12": "twilight_morning_12deg",
-}
+def _current_dayobs_utc(now_utc: pd.Timestamp | datetime) -> int:
+    """Compute the current dayobs from a UTC timestamp.
 
-
-def _dayobs_range(start_dayobs: int, end_dayobs_exclusive: int) -> list[int]:
-    """List of dayobs ints from start_dayobs up to
-    (excluding) end_dayobs_exclusive."""
-    days = []
-    current = start_dayobs
-    while current < end_dayobs_exclusive:
-        days.append(current)
-        current = add_or_subtract_dayobs_days(current, 1)
-    return days
-
-
-def _almanac_by_visit_dayobs(almanac_info: list[dict]) -> dict[int, dict]:
-    """Map each almanac record to the visit day_obs it covers.
-
-    Mirrors the mapping already established for time accounting: the
-    almanac service labels a night's record with the dayobs of its
-    *morning* twilight -- one calendar day after the day_obs visits
-    taken that night are tagged with.
+    A dayobs runs from noon UTC to noon UTC, so subtracting 12 hours
+    and taking the date gives the correct dayobs for any time in that
+    window.
     """
-    return {add_or_subtract_dayobs_days(record["dayobs"], -1): record for record in almanac_info}
+    return int((now_utc - timedelta(hours=12)).strftime("%Y%m%d"))
 
 
-def _build_missing_dayobs_row(
-    dayobs: int,
-    columns: pd.Index,
-    almanac_record: dict | None,
-) -> dict[str, Any]:
-    """Construct a placeholder row for a dayobs missing from dome_open.
+def _compute_closed_hours(
+    row: pd.Series,
+    current_dayobs: int,
+    now_utc: datetime,
+) -> float:
+    """Compute closed_hours for a single dome row.
 
-    Mirrors the shape of a real "dome closed all night" row (e.g.
-    dome_hours/open_hours: 0, open_time/close_time: null), except
-    sunset12/sunrise12/night_hours are backfilled from the matching
-    almanac record rather than measured, since no real dome event
-    exists to derive them from.
+    The input row may come either from the raw dome-open dataframe
+    (where ``day_obs`` is a column) or from a dataframe aggregated by
+    ``day_obs`` (where it becomes the Series name / index key).
+
+    Three cases:
+
+    Past night (day_obs < current_dayobs):
+        closed_hours = night_hours - open_hours.
+
+    Current night in progress, dome has not opened (open_hours == 0):
+        closed_hours = elapsed time since evening twilight (sunset12).
+
+    Current night in progress, dome has opened (open_hours > 0):
+        closed_hours = night_hours - open_hours..
+        `rubin-nights` calculates open_hours based on elapsed times
+        when the dome has opened but haven't closed yet.
     """
-    row: dict[str, Any] = {}
-    for col in columns:
-        if col == "day_obs":
-            row[col] = int(dayobs)
-        elif col in _ZERO_DURATION_COLUMNS:
-            row[col] = 0.0
-        elif col in _NULL_TIME_COLUMNS:
-            row[col] = pd.NaT
-        elif col == "night_hours":
-            row[col] = almanac_record.get("night_hours") if almanac_record else np.nan
-        elif col in _ALMANAC_TWILIGHT_COLUMN_MAP:
-            almanac_key = _ALMANAC_TWILIGHT_COLUMN_MAP[col]
-            value = almanac_record.get(almanac_key) if almanac_record else None
-            row[col] = pd.Timestamp(value) if value else pd.NaT
-        else:
-            logger.warning(
-                f"sanitize_dome_open_close: no fill rule for column '{col}' "
-                f"on synthesized row for missing dayobs {dayobs}; defaulting to NaN"
-            )
-            row[col] = np.nan
-    return row
+    day_obs = row.get("day_obs", row.name)
+    sunset12_utc = pd.to_datetime(row["sunset12"], utc=True)
+    sunrise12_utc = pd.to_datetime(row["sunrise12"], utc=True)
+
+    night_in_progress = (
+        day_obs == current_dayobs
+        and pd.notna(sunset12_utc)
+        and pd.notna(sunrise12_utc)
+        and sunset12_utc <= now_utc <= sunrise12_utc
+    )
+
+    if not night_in_progress:
+        return row["night_hours"] - row["open_hours"]
+
+    elapsed_hours = (now_utc - sunset12_utc).total_seconds() / 3600
+
+    if row["open_hours"] == 0:
+        return elapsed_hours
+    else:
+        return row["night_hours"] - row["open_hours"]
 
 
-def sanitize_dome_open_close(
-    dome_open: pd.DataFrame,
-    dayObsStart: int,
-    dayObsEnd: int,
-) -> pd.DataFrame:
-    """Restrict and complete dome open/close records for the requested
-    night range.
+def _elapsed_night_hours(
+    row: pd.Series,
+    current_dayobs: int,
+    now_utc: pd.Timestamp,
+) -> float:
+    """Hours elapsed since evening twilight, capped at night_hours.
 
-    Three corrections are applied:
-
-    1. Normalize schema: dome_open is reindexed onto _DOME_OPEN_COLUMNS
-       so every row -- real or synthesized -- always carries the full
-       expected field set. The upstream response has been observed to
-       sometimes omit columns entirely (not just leave them null) on a
-       given call; without this step, that omission would silently
-       propagate into every row, including any synthesized placeholder
-       rows built in step 3, which would otherwise inherit the same gap.
-    2. Trim: get_dome_open_close is queried over
-       [noon(dayObsStart), noon(dayObsEnd)], which spans nights
-       dayObsStart through (dayObsEnd - 1) inclusive -- dayObsEnd itself
-       is only the boundary timestamp. It has been observed to
-       occasionally return a trailing extra dayObs beyond that
-       boundary; this trims it back to exactly the requested range.
-    3. Fill: any dayobs in the requested range with no entry at all in
-       the trimmed result gets a synthesized placeholder row -- twilight
-       times and night_hours from get_almanac, 0 for duration columns,
-       NaT for open/close time columns. See _build_missing_dayobs_row.
+    For past nights, returns night_hours (the night is complete).
+    For the current night in progress, returns time elapsed since
+    sunset12 -- this is the correct baseline for fault time, since
+    exposure_time, overhead, and weather_loss all only reflect what
+    has happened so far, not the full projected night.
 
     Parameters
     ----------
-    dome_open : pd.DataFrame
-        Raw dome open/close records, expected to carry day_obs (YYYYMMDD
-        ints) as either a column or the index.
-    dayObsStart : int
-        Start of the requested dayObs range (inclusive).
-    dayObsEnd : int
-        End of the requested dayObs range (the boundary timestamp;
-        the last valid night is dayObsEnd - 1).
+    row : pd.Series
+        Aggregated per-night dome row with sunset12, sunrise12,
+        night_hours, and day_obs.
+    current_dayobs : int
+        The dayobs currently in progress.
+    now_utc : pd.Timestamp
+        Current UTC time, timezone-aware.
 
     Returns
     -------
-    pd.DataFrame
-        Exactly one entry per night in [dayObsStart, dayObsEnd - 1],
-        with a consistent schema of _DOME_OPEN_COLUMNS, sorted by
-        day_obs. Returns the input unchanged if day_obs can't be
-        located as either a column or the index name.
+    float
+        Elapsed night hours to use as the fault time baseline.
     """
-    if dome_open is None:
-        dome_open = pd.DataFrame()
+    day_obs = row.get("day_obs", row.name)
+    sunset12_utc = pd.to_datetime(row["sunset12"], utc=True)
+    sunrise12_utc = pd.to_datetime(row["sunrise12"], utc=True)
 
-    # Normalise day_obs to a plain column regardless of how it arrived.
-    if not dome_open.empty and "day_obs" not in dome_open.columns:
-        if dome_open.index.name == "day_obs":
-            dome_open = dome_open.reset_index()
-        else:
-            logger.warning(
-                "sanitize_dome_open_close: could not locate 'day_obs' as a "
-                "column or index name; returning data unfiltered"
-            )
-            return dome_open
+    night_in_progress = (
+        day_obs == current_dayobs
+        and pd.notna(sunset12_utc)
+        and pd.notna(sunrise12_utc)
+        and sunset12_utc <= now_utc <= sunrise12_utc
+    )
 
-    if not dome_open.empty:
-        missing_columns = [c for c in _DOME_OPEN_COLUMNS if c not in dome_open.columns]
-        if missing_columns:
-            logger.warning(
-                f"sanitize_dome_open_close: dome_open response is missing "
-                f"expected column(s) {missing_columns}; filling with NaN. "
-                f"This likely indicates an upstream schema gap worth "
-                f"investigating, distinct from a missing-dayobs gap."
-            )
-        # Reindex onto the canonical column set: adds any missing columns
-        # as NaN, drops/ignores anything unexpected, and fixes column
-        # order -- guaranteeing every row that follows has the full schema.
-        dome_open = dome_open.reindex(columns=_DOME_OPEN_COLUMNS)
+    if not night_in_progress:
+        return row["night_hours"]
 
-    last_valid_dayobs = add_or_subtract_dayobs_days(dayObsEnd, -1)
-    requested_dayobs = _dayobs_range(dayObsStart, dayObsEnd)
-
-    if dome_open.empty:
-        trimmed = pd.DataFrame(columns=_DOME_OPEN_COLUMNS)
-        present_dayobs: set[int] = set()
-    else:
-        in_range = (dome_open["day_obs"] >= dayObsStart) & (dome_open["day_obs"] <= last_valid_dayobs)
-        dropped = int((~in_range).sum())
-        if dropped:
-            logger.info(
-                f"sanitize_dome_open_close: dropping {dropped} row(s) outside "
-                f"[{dayObsStart}, {last_valid_dayobs}]"
-            )
-        trimmed = dome_open.loc[in_range]
-        present_dayobs = set(trimmed["day_obs"])
-
-    missing_dayobs = [d for d in requested_dayobs if d not in present_dayobs]
-
-    if missing_dayobs:
-        logger.info(
-            f"sanitize_dome_open_close: synthesizing placeholder rows for "
-            f"dayobs missing from dome data: {missing_dayobs}"
-        )
-        almanac_info = get_almanac(dayObsStart, dayObsEnd)
-        almanac_by_dayobs = _almanac_by_visit_dayobs(almanac_info)
-
-        new_rows = [
-            _build_missing_dayobs_row(d, _DOME_OPEN_COLUMNS, almanac_by_dayobs.get(d)) for d in missing_dayobs
-        ]
-        trimmed = pd.concat(
-            [trimmed, pd.DataFrame(new_rows, columns=_DOME_OPEN_COLUMNS)],
-            ignore_index=True,
-        )
-
-    return trimmed.sort_values("day_obs").reset_index(drop=True)
+    return (now_utc - sunset12_utc).total_seconds() / 3600
 
 
 def get_open_close_dome(
@@ -434,27 +346,29 @@ def get_open_close_dome(
     dayObsEnd: int,
     instrument: str,
     auth_token: str = None,
-) -> dict:
-    """Retrieve the dome open and close times for a specified
-    range of observation days and instrument.
-    Currently only for Simonyi.
+) -> pd.DataFrame:
+    """Retrieve dome open/close records for the requested night range.
 
     Parameters
     ----------
     dayObsStart : int
         The starting observation day (as an integer, e.g., YYYYMMDD).
     dayObsEnd : int
-        The ending observation day (as an integer, e.g., YYYYMMDD).
+        The exclusive upper boundary observation day (as an integer,
+        e.g., YYYYMMDD). The last returned night is ``dayObsEnd - 1``.
     instrument : str
-        The name of the instrument for which to retrieve dome open/close times.
+        The instrument name. Currently logged but not used to filter
+        the dome query.
     auth_token : str, optional
         Authentication token used when connecting to Rubin Observatory
         services.
 
     Returns
     -------
-    dict
-        A dictionary containing the dome open and close times.
+    pd.DataFrame
+        Dome open/close records sanitized to one row per requested
+        ``day_obs`` in ``[dayObsStart, dayObsEnd - 1]``, with the
+        canonical schema defined by ``_DOME_OPEN_COLUMNS``.
     """
     logger.info(
         f"Getting open/close dome times from rubin-nights for dayObsStart: {dayObsStart}, "
@@ -466,7 +380,11 @@ def get_open_close_dome(
     day_min = dayobs_to_noon_utc(dayObsStart)
     day_max = dayobs_to_noon_utc(dayObsEnd)
     dome_open = get_dome_open_close(day_min, day_max, clients["efd"])
-    return sanitize_dome_open_close(dome_open, dayObsStart, dayObsEnd)
+
+    if "day_obs" not in dome_open.columns and dome_open.index.name == "day_obs":
+        dome_open = dome_open.reset_index()
+
+    return dome_open
 
 
 def get_context_feed(

--- a/tests/test_almanac_service.py
+++ b/tests/test_almanac_service.py
@@ -1,0 +1,49 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from lsst.ts.logging_and_reporting.web_app.services.almanac_service import (
+    _compute_elapsed_twilight_hours,
+)
+
+EVENING_TWILIGHT = "2026-04-09T23:00:00+00:00"
+MORNING_TWILIGHT = "2026-04-10T10:00:00+00:00"
+NIGHT_HOURS = 11.0
+
+
+class TestComputeElapsedTwilightHours:
+    def test_future_night_returns_zero(self):
+        now_utc = datetime(2026, 4, 9, 22, 0, tzinfo=UTC)
+        assert _compute_elapsed_twilight_hours(
+            NIGHT_HOURS,
+            EVENING_TWILIGHT,
+            MORNING_TWILIGHT,
+            now_utc,
+        ) == pytest.approx(0.0)
+
+    def test_current_night_in_progress_returns_elapsed_hours(self):
+        now_utc = datetime(2026, 4, 10, 2, 0, tzinfo=UTC)
+        assert _compute_elapsed_twilight_hours(
+            NIGHT_HOURS,
+            EVENING_TWILIGHT,
+            MORNING_TWILIGHT,
+            now_utc,
+        ) == pytest.approx(3.0)
+
+    def test_completed_night_returns_full_night_hours(self):
+        now_utc = datetime(2026, 4, 10, 12, 0, tzinfo=UTC)
+        assert _compute_elapsed_twilight_hours(
+            NIGHT_HOURS,
+            EVENING_TWILIGHT,
+            MORNING_TWILIGHT,
+            now_utc,
+        ) == pytest.approx(NIGHT_HOURS)
+
+    def test_elapsed_hours_are_capped_at_night_hours(self):
+        now_utc = datetime(2026, 4, 10, 2, 0, tzinfo=UTC)
+        assert _compute_elapsed_twilight_hours(
+            2.0,
+            EVENING_TWILIGHT,
+            MORNING_TWILIGHT,
+            now_utc,
+        ) == pytest.approx(2.0)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -818,7 +818,6 @@ def test_exposures_endpoint_returns_updated_fields(monkeypatch):
         patch("lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome") as mock_open_close,
         patch("lsst.ts.logging_and_reporting.web_app.main.get_time_accounting") as mock_time_accounting,
         patch("lsst.ts.logging_and_reporting.web_app.main._compute_closed_hours", return_value=7.0),
-        patch("lsst.ts.logging_and_reporting.web_app.main._elapsed_night_hours", return_value=5.0),
     ):
         mock_open_close.return_value = pd.DataFrame(
             [
@@ -863,7 +862,6 @@ def test_exposures_endpoint_returns_updated_fields(monkeypatch):
                 "sunset12": "2025-07-30T23:00:00Z",
                 "sunrise12": "2025-07-31T11:00:00Z",
                 "closed_hours": 7.0,
-                "elapsed_night_hours": 5.0,
             }
         }
         assert data["open_dome_error"] is None
@@ -973,6 +971,46 @@ def test_exposures_endpoint_time_accounting_error(monkeypatch):
         assert data["time_accounting_error"] == "Failed to compute night time accounting"
 
 
+def test_exposures_endpoint_no_exposures_returns_zeroed_time_accounting(monkeypatch):
+    endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
+    zeroed_time_accounting = {
+        "sum_overhead_with_filter_change": 0.0,
+        "sum_overhead_without_filter_change": 0.0,
+        "sum_visit_gap_with_filter_change": 0.0,
+        "sum_visit_gap_without_filter_change": 0.0,
+    }
+
+    with (
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_exposures",
+            return_value=[],
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome",
+            side_effect=RuntimeError("efd unavailable"),
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_time_accounting",
+            return_value=zeroed_time_accounting,
+        ),
+    ):
+        _test_endpoint_authentication(endpoint, monkeypatch)
+
+        response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exposures"] == []
+        assert data["exposures_count"] == 0
+        assert data["sum_exposure_time"] == 0
+        assert data["on_sky_exposures_count"] == 0
+        assert data["total_on_sky_exposure_time"] == 0
+        assert data["open_dome_times"] is None
+        assert data["day_obs_open_dome_hours"] is None
+        assert data["open_dome_error"] == "Failed to retrieve dome open/close times"
+        assert data["night_on_sky_time_accounting"] == zeroed_time_accounting
+        assert data["time_accounting_error"] is None
+
+
 def test_jira_endpoint_authentication(monkeypatch):
     endpoint = "/jira-tickets?dayObsStart=1&dayObsEnd=2&instrument=LATISS"
 
@@ -1031,15 +1069,24 @@ def test_jira_tickets_endpoint(mock_requests_get, monkeypatch):
 
 
 def test_almanac_endpoint(monkeypatch):
+    mock_almanac = [
+        {
+            "dayobs": 20240102,
+            "night_hours": 9.5,
+            "elapsed_twilight_hours": 3.25,
+            "twilight_evening_12deg": "2024-01-01 23:00:00",
+            "twilight_morning_12deg": "2024-01-02 08:30:00",
+        }
+    ]
     monkeypatch.setattr(
         "lsst.ts.logging_and_reporting.web_app.main.get_almanac",
-        lambda dayObsStart, dayObsEnd: {"sunset": 123, "sunrise": 456},
+        lambda dayObsStart, dayObsEnd: mock_almanac,
     )
     response = client.get("/almanac?dayObsStart=20240101&dayObsEnd=20240102")
     assert response.status_code == 200
     data = response.json()
     assert "almanac_info" in data
-    assert data["almanac_info"] == {"sunset": 123, "sunrise": 456}
+    assert data["almanac_info"] == mock_almanac
 
 
 def test_context_feed_endpoint(monkeypatch):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -820,30 +820,12 @@ def test_exposures_endpoint(mock_requests_get, mock_requests_post, monkeypatch):
                 }
             ]
         )
-        mock_time_accounting.return_value = pd.DataFrame(
-            {
-                "exposure_id": [2025073000001],
-                "exposure_name": ["MC_O_20250730_000001"],
-                "exp_time": [30],
-                "img_type": ["science"],
-                "observation_reason": ["BLOCK-365"],
-                "science_program": ["field_survey_science"],
-                "target_name": ["Rubin_SV_225_-40"],
-                "can_see_sky": [True],
-                "band": ["r"],
-                "obs_start": ["2025-07-30T23:33:43.069000"],
-                "physical_filter": ["r_57"],
-                "day_obs": [20250730],
-                "seq_num": [1],
-                "obs_end": ["2025-07-30T23:34:13.999000"],
-                "overhead": [9.0],
-                "zero_point_median": [32.1],
-                "visit_id": [2025071600135],
-                "pixel_scale_median": [0.2],
-                "psf_sigma_median": [1.1],
-                "visit_gap": [3],
-            }
-        )
+        mock_time_accounting.return_value = {
+            "sum_overhead_with_filter_change": 0.0,
+            "sum_overhead_without_filter_change": 0.0,
+            "sum_visit_gap_with_filter_change": 0.0,
+            "sum_visit_gap_without_filter_change": 0.0,
+        }
         app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
         app.dependency_overrides[get_clients] = lambda: {"efd": Mock()}
 
@@ -862,19 +844,26 @@ def test_exposures_endpoint(mock_requests_get, mock_requests_post, monkeypatch):
                 "open_hours": 9.05935107777778,
             }
         ]
+        assert data["night_on_sky_time_accounting"] == {
+            "sum_overhead_with_filter_change": 0.0,
+            "sum_overhead_without_filter_change": 0.0,
+            "sum_visit_gap_with_filter_change": 0.0,
+            "sum_visit_gap_without_filter_change": 0.0,
+        }
         mock_time_accounting.assert_called_once()
         mock_open_close.assert_called_once()
 
         # test that the request succeeds if the
         # rubin_nights data wasn't available
         mock_open_close.return_value = pd.DataFrame()
-        mock_time_accounting.return_value = pd.DataFrame()
+        mock_time_accounting.return_value = {}
         response = client.get(endpoint)
         assert response.status_code == 200
         data = response.json()
         assert "exposures" in data
         assert data["exposures_count"] == 1
         assert data["open_dome_times"] == []
+        assert data["night_on_sky_time_accounting"] == {}
 
         app.dependency_overrides.pop(rsp_auth, None)
         app.dependency_overrides.pop(get_clients, None)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -28,7 +28,6 @@ import pytest
 import requests
 from bokeh.plotting import figure
 from fastapi.testclient import TestClient
-from rubin_nights.connections import get_clients
 
 import lsst.ts.logging_and_reporting.utils as ut
 from lsst.ts.logging_and_reporting import __version__
@@ -800,73 +799,178 @@ def test_exposure_entries_endpoint(mock_requests_get, monkeypatch):
     app.dependency_overrides.pop(rsp_auth, None)
 
 
-def test_exposures_endpoint(mock_requests_get, mock_requests_post, monkeypatch):
+def test_exposures_endpoint_returns_updated_fields(monkeypatch):
     endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
-    _test_endpoint_authentication(endpoint, monkeypatch)
+    exposures = [
+        {"id": 1, "can_see_sky": True, "exp_time": 30},
+        {"id": 2, "can_see_sky": False, "exp_time": 20},
+        {"id": 3, "can_see_sky": True, "exp_time": None},
+    ]
+    time_accounting = {
+        "sum_overhead_with_filter_change": 0.0,
+        "sum_overhead_without_filter_change": 0.0,
+        "sum_visit_gap_with_filter_change": 0.0,
+        "sum_visit_gap_without_filter_change": 0.0,
+    }
 
     with (
+        patch("lsst.ts.logging_and_reporting.web_app.main.get_exposures", return_value=exposures),
         patch("lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome") as mock_open_close,
         patch("lsst.ts.logging_and_reporting.web_app.main.get_time_accounting") as mock_time_accounting,
+        patch("lsst.ts.logging_and_reporting.web_app.main._compute_closed_hours", return_value=7.0),
+        patch("lsst.ts.logging_and_reporting.web_app.main._elapsed_night_hours", return_value=5.0),
     ):
-        import pandas as pd
-
         mock_open_close.return_value = pd.DataFrame(
             [
                 {
                     "day_obs": 20250730,
                     "open_time": "2025-07-30T23:11:57.696481",
                     "close_time": "2025-07-31T08:15:31.360361",
+                    "night_hours": 12.0,
                     "open_hours": 9.05935107777778,
+                    "sunset12": "2025-07-30T23:00:00Z",
+                    "sunrise12": "2025-07-31T11:00:00Z",
                 }
             ]
         )
-        mock_time_accounting.return_value = {
-            "sum_overhead_with_filter_change": 0.0,
-            "sum_overhead_without_filter_change": 0.0,
-            "sum_visit_gap_with_filter_change": 0.0,
-            "sum_visit_gap_without_filter_change": 0.0,
-        }
-        app.dependency_overrides[rsp_auth] = lambda: "dummy-token"
-        app.dependency_overrides[get_clients] = lambda: {"efd": Mock()}
+        mock_time_accounting.return_value = time_accounting
 
-        response = client.get(endpoint)
+        _test_endpoint_authentication(endpoint, monkeypatch)
+
+        response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
         assert response.status_code == 200
         data = response.json()
         assert "exposures" in data
-        assert data["exposures_count"] == 1
-        assert data["sum_exposure_time"] == 30
-        assert data["on_sky_exposures_count"] == 1
+        assert data["exposures_count"] == 3
+        assert data["sum_exposure_time"] == 50
+        assert data["on_sky_exposures_count"] == 2
+        assert data["total_on_sky_exposure_time"] == 30
         assert data["open_dome_times"] == [
             {
                 "day_obs": 20250730,
                 "open_time": "2025-07-30T23:11:57.696481",
                 "close_time": "2025-07-31T08:15:31.360361",
+                "night_hours": 12.0,
                 "open_hours": 9.05935107777778,
+                "sunset12": "2025-07-30T23:00:00Z",
+                "sunrise12": "2025-07-31T11:00:00Z",
             }
         ]
-        assert data["night_on_sky_time_accounting"] == {
-            "sum_overhead_with_filter_change": 0.0,
-            "sum_overhead_without_filter_change": 0.0,
-            "sum_visit_gap_with_filter_change": 0.0,
-            "sum_visit_gap_without_filter_change": 0.0,
+        assert data["day_obs_open_dome_hours"] == {
+            "20250730": {
+                "night_hours": 12.0,
+                "open_hours": 9.05935107777778,
+                "sunset12": "2025-07-30T23:00:00Z",
+                "sunrise12": "2025-07-31T11:00:00Z",
+                "closed_hours": 7.0,
+                "elapsed_night_hours": 5.0,
+            }
         }
-        mock_time_accounting.assert_called_once()
-        mock_open_close.assert_called_once()
+        assert data["open_dome_error"] is None
+        assert data["night_on_sky_time_accounting"] == time_accounting
+        assert data["time_accounting_error"] is None
+        assert mock_time_accounting.call_count == 4
+        assert mock_open_close.call_count == 4
 
-        # test that the request succeeds if the
-        # rubin_nights data wasn't available
-        mock_open_close.return_value = pd.DataFrame()
-        mock_time_accounting.return_value = {}
-        response = client.get(endpoint)
+
+def test_exposures_endpoint_open_dome_aggregation_error(monkeypatch):
+    endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
+
+    with (
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_exposures",
+            return_value=[{"id": 1, "can_see_sky": True, "exp_time": 30}],
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome",
+            return_value=pd.DataFrame(
+                [
+                    {
+                        "day_obs": 20250730,
+                        "open_time": "2025-07-30T23:11:57.696481",
+                        "close_time": "2025-07-31T08:15:31.360361",
+                        "night_hours": 12.0,
+                        "open_hours": 9.05935107777778,
+                        "sunset12": "2025-07-30T23:00:00Z",
+                        "sunrise12": "2025-07-31T11:00:00Z",
+                    }
+                ]
+            ),
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main._compute_closed_hours",
+            side_effect=RuntimeError("aggregation failed"),
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_time_accounting",
+            return_value={"sum_overhead_with_filter_change": 0.0},
+        ),
+    ):
+        _test_endpoint_authentication(endpoint, monkeypatch)
+
+        response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
         assert response.status_code == 200
         data = response.json()
-        assert "exposures" in data
-        assert data["exposures_count"] == 1
-        assert data["open_dome_times"] == []
-        assert data["night_on_sky_time_accounting"] == {}
+        assert len(data["open_dome_times"]) == 1
+        assert data["day_obs_open_dome_hours"] is None
+        assert data["open_dome_error"] == "Failed to aggregate dome open hours"
+        assert data["night_on_sky_time_accounting"] == {"sum_overhead_with_filter_change": 0.0}
+        assert data["time_accounting_error"] is None
 
-        app.dependency_overrides.pop(rsp_auth, None)
-        app.dependency_overrides.pop(get_clients, None)
+
+def test_exposures_endpoint_open_dome_retrieval_error(monkeypatch):
+    endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
+
+    with (
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_exposures",
+            return_value=[{"id": 1, "can_see_sky": True, "exp_time": 30}],
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome",
+            side_effect=RuntimeError("efd unavailable"),
+        ),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_time_accounting",
+            return_value={"sum_overhead_with_filter_change": 0.0},
+        ),
+    ):
+        _test_endpoint_authentication(endpoint, monkeypatch)
+
+        response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["open_dome_times"] is None
+        assert data["day_obs_open_dome_hours"] is None
+        assert data["open_dome_error"] == "Failed to retrieve dome open/close times"
+        assert data["night_on_sky_time_accounting"] == {"sum_overhead_with_filter_change": 0.0}
+        assert data["time_accounting_error"] is None
+
+
+def test_exposures_endpoint_time_accounting_error(monkeypatch):
+    endpoint = "/exposures?dayObsStart=20240101&dayObsEnd=20240102&instrument=LSSTCam"
+
+    with (
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_exposures",
+            return_value=[{"id": 1, "can_see_sky": True, "exp_time": 30}],
+        ),
+        patch("lsst.ts.logging_and_reporting.web_app.main.get_open_close_dome", return_value=pd.DataFrame()),
+        patch(
+            "lsst.ts.logging_and_reporting.web_app.main.get_time_accounting",
+            side_effect=RuntimeError("time accounting failed"),
+        ),
+    ):
+        _test_endpoint_authentication(endpoint, monkeypatch)
+
+        response = client.get(endpoint, headers={"Authorization": "Bearer header-token"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["open_dome_times"] == []
+        assert data["day_obs_open_dome_hours"] == {}
+        assert data["open_dome_error"] is None
+        assert data["night_on_sky_time_accounting"] is None
+        assert data["time_accounting_error"] == "Failed to compute night time accounting"
 
 
 def test_jira_endpoint_authentication(monkeypatch):

--- a/tests/test_dome_hours.py
+++ b/tests/test_dome_hours.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from lsst.ts.logging_and_reporting.utils import current_dayobs_utc
 from lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service import (
     _compute_closed_hours,
-    _current_dayobs_utc,
     get_open_close_dome,
 )
 
@@ -71,35 +71,35 @@ def make_raw_dome_df(*sessions: dict) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# _current_dayobs_utc
+# current_dayobs_utc
 # ---------------------------------------------------------------------------
 
 
 class TestCurrentDayobsUtc:
     def test_after_noon_utc_returns_same_date(self):
         now = pd.Timestamp("2026-04-09 15:00:00", tz="UTC")
-        assert _current_dayobs_utc(now) == 20260409
+        assert current_dayobs_utc(now) == 20260409
 
     def test_before_noon_utc_returns_previous_date(self):
         # 03:00 UTC April 10 is still dayobs 20260409
         now = pd.Timestamp("2026-04-10 03:00:00", tz="UTC")
-        assert _current_dayobs_utc(now) == 20260409
+        assert current_dayobs_utc(now) == 20260409
 
     def test_exactly_at_noon_utc_returns_same_date(self):
         now = pd.Timestamp("2026-04-09 12:00:00", tz="UTC")
-        assert _current_dayobs_utc(now) == 20260409
+        assert current_dayobs_utc(now) == 20260409
 
     def test_one_second_before_noon_returns_previous_date(self):
         now = pd.Timestamp("2026-04-09 11:59:59", tz="UTC")
-        assert _current_dayobs_utc(now) == 20260408
+        assert current_dayobs_utc(now) == 20260408
 
     def test_month_boundary(self):
         now = pd.Timestamp("2026-05-01 03:00:00", tz="UTC")
-        assert _current_dayobs_utc(now) == 20260430
+        assert current_dayobs_utc(now) == 20260430
 
     def test_year_boundary(self):
         now = pd.Timestamp("2027-01-01 03:00:00", tz="UTC")
-        assert _current_dayobs_utc(now) == 20261231
+        assert current_dayobs_utc(now) == 20261231
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dome_hours.py
+++ b/tests/test_dome_hours.py
@@ -8,7 +8,6 @@ import pytest
 from lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service import (
     _compute_closed_hours,
     _current_dayobs_utc,
-    _elapsed_night_hours,
     get_open_close_dome,
 )
 
@@ -212,66 +211,6 @@ class TestComputeClosedHoursEdgeCases:
         )
         now_utc = SUNSET12 + timedelta(hours=3)
         assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
-
-
-# ---------------------------------------------------------------------------
-# _elapsed_night_hours
-# ---------------------------------------------------------------------------
-
-
-class TestElapsedNightHours:
-    def test_past_night_returns_full_night_hours(self):
-        row = make_aggregated_row(day_obs=PREV_DAYOBS, night_hours=11.0)
-        now_utc = SUNSET12 + timedelta(hours=2)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
-
-    def test_current_night_in_progress_returns_elapsed(self):
-        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
-        now_utc = SUNSET12 + timedelta(hours=3)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(3.0)
-
-    def test_current_night_just_started(self):
-        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
-        now_utc = SUNSET12 + timedelta(minutes=30)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(0.5)
-
-    def test_future_night_returns_full_night_hours(self):
-        row = make_aggregated_row(
-            day_obs=NEXT_DAYOBS,
-            sunset12=pd.Timestamp("2026-04-10 23:00:00", tz="UTC"),
-            sunrise12=pd.Timestamp("2026-04-11 10:00:00", tz="UTC"),
-            night_hours=11.0,
-        )
-        now_utc = SUNSET12 + timedelta(hours=2)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
-
-    def test_now_before_sunset12_on_current_dayobs_returns_full_night_hours(self):
-        # Current dayobs but before the night has started -- not in progress.
-        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
-        now_utc = SUNSET12 - timedelta(hours=1)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
-
-    def test_nat_sunset12_falls_back_to_full_night_hours(self):
-        row = make_aggregated_row(day_obs=DAYOBS, sunset12=pd.NaT, night_hours=NIGHT_HOURS)
-        now_utc = SUNSET12 + timedelta(hours=3)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
-
-    def test_elapsed_never_exceeds_night_hours(self):
-        # now_utc is past sunrise -- still returns elapsed since sunset,
-        # but the night_in_progress condition (now <= sunrise12) is False,
-        # so it returns night_hours instead.
-        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
-        now_utc = SUNRISE12 + timedelta(hours=2)
-        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
-
-    def test_elapsed_is_consistent_with_closed_hours_when_dome_closed(self):
-        # When the dome never opened, elapsed_night_hours - 0 open_hours
-        # should equal closed_hours for a night in progress.
-        row = make_aggregated_row(day_obs=DAYOBS, open_hours=0.0, night_hours=NIGHT_HOURS)
-        now_utc = SUNSET12 + timedelta(hours=4)
-        elapsed = _elapsed_night_hours(row, DAYOBS, now_utc)
-        closed = _compute_closed_hours(row, DAYOBS, now_utc)
-        assert elapsed == pytest.approx(closed)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dome_hours.py
+++ b/tests/test_dome_hours.py
@@ -152,30 +152,38 @@ class TestComputeClosedHoursCurrentNight:
         assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(2.0)
 
     def test_single_open_session_currently_active(self):
-        # Dome has been open for 3hrs (rubin-nights tracks elapsed open
-        # time for an active session). closed = night_hours - open_hours.
+        # Dome has been open for 3hrs and the night is 5hrs old,
+        # so closed so far is 2hrs.
         row = make_aggregated_row(day_obs=DAYOBS, open_hours=3.0, night_hours=NIGHT_HOURS)
         now_utc = SUNSET12 + timedelta(hours=5)
-        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 3.0)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(2.0)
 
     def test_past_closed_session_then_current_open_session(self):
         # Session 1: dome open 1hr, closed 1hr. Session 2: currently open 3hrs.
-        # Aggregated open_hours = 1 + 3 = 4.
+        # Aggregated open_hours = 1 + 3 = 4, elapsed twilight = 6hrs,
+        # so closed so far is 2hrs.
         row = make_aggregated_row(day_obs=DAYOBS, open_hours=4.0, night_hours=NIGHT_HOURS)
         now_utc = SUNSET12 + timedelta(hours=6)
-        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 4.0)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(2.0)
 
     def test_multiple_past_open_sessions_no_current_open(self):
-        # Two completed sessions (2hrs + 1.5hrs = 3.5hrs), dome now closed.
-        # Because open_hours > 0, use night_hours - open_hours.
+        # Two completed sessions (2hrs + 1.5hrs = 3.5hrs), dome now closed,
+        # 7hrs into the night, so closed so far is 3.5hrs.
         row = make_aggregated_row(day_obs=DAYOBS, open_hours=3.5, night_hours=NIGHT_HOURS)
         now_utc = SUNSET12 + timedelta(hours=7)
-        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 3.5)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(3.5)
 
     def test_just_after_evening_twilight_dome_closed(self):
         row = make_aggregated_row(day_obs=DAYOBS, open_hours=0.0, night_hours=NIGHT_HOURS)
         now_utc = SUNSET12 + timedelta(minutes=1)
         assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(1 / 60)
+
+    def test_open_hours_greater_than_elapsed_clamps_to_zero(self):
+        # Guard against slight timing mismatches between almanac twilight
+        # and upstream open_hours for the current night.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=3.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(0.0)
 
 
 class TestComputeClosedHoursEdgeCases:
@@ -271,13 +279,6 @@ class TestGetOpenCloseDome:
         with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
             result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
         assert "closed_hours" not in result.columns
-
-    def test_day_obs_as_index_normalised_to_column(self, mock_clients):
-        raw = make_raw_dome_df({"day_obs": DAYOBS}).set_index("day_obs")
-        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
-            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
-        assert "day_obs" in result.columns
-        assert result.index.name != "day_obs"
 
     def test_multiple_nights_each_session_preserved(self, mock_clients):
         raw = make_raw_dome_df(

--- a/tests/test_dome_hours.py
+++ b/tests/test_dome_hours.py
@@ -1,0 +1,353 @@
+# tests/test_dome_closed_hours.py
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service import (
+    _compute_closed_hours,
+    _current_dayobs_utc,
+    _elapsed_night_hours,
+    get_open_close_dome,
+)
+
+MODULE = "lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service"
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+DAYOBS = 20260409
+PREV_DAYOBS = 20260408
+NEXT_DAYOBS = 20260410
+
+SUNSET12 = pd.Timestamp("2026-04-09 23:00:00", tz="UTC")
+SUNRISE12 = pd.Timestamp("2026-04-10 10:00:00", tz="UTC")
+NIGHT_HOURS = (SUNRISE12 - SUNSET12).total_seconds() / 3600  # 11.0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_session(**kwargs) -> dict:
+    """A single dome open session row -- the unit
+    get_dome_open_close returns.
+    """
+    defaults = {
+        "day_obs": DAYOBS,
+        "open_time": pd.Timestamp("2026-04-09 23:30:00"),
+        "close_time": pd.Timestamp("2026-04-10 05:00:00"),
+        "dome_hours": 5.5,
+        "sunset12": pd.Timestamp("2026-04-09 23:00:00"),  # naive, UTC
+        "sunrise12": pd.Timestamp("2026-04-10 10:00:00"),
+        "night_hours": NIGHT_HOURS,
+        "open_hours": 5.5,
+    }
+    return {**defaults, **kwargs}
+
+
+def make_aggregated_row(**kwargs) -> pd.Series:
+    """A per-night aggregated row -- what _compute_closed_hours operates on.
+    Mirrors the output of groupby(...).agg(night_hours=max, open_hours=sum,
+    sunset12=first, sunrise12=first).
+    """
+    defaults = {
+        "night_hours": NIGHT_HOURS,
+        "open_hours": 0.0,
+        "sunset12": SUNSET12,
+        "sunrise12": SUNRISE12,
+        # day_obs is the groupby index, not a column, but we include it
+        # in the Series so _compute_closed_hours can access it.
+        "day_obs": DAYOBS,
+    }
+    return pd.Series({**defaults, **kwargs})
+
+
+def make_raw_dome_df(*sessions: dict) -> pd.DataFrame:
+    """Build a raw per-session DataFrame."""
+    return pd.DataFrame([make_session(**s) for s in sessions])
+
+
+# ---------------------------------------------------------------------------
+# _current_dayobs_utc
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentDayobsUtc:
+    def test_after_noon_utc_returns_same_date(self):
+        now = pd.Timestamp("2026-04-09 15:00:00", tz="UTC")
+        assert _current_dayobs_utc(now) == 20260409
+
+    def test_before_noon_utc_returns_previous_date(self):
+        # 03:00 UTC April 10 is still dayobs 20260409
+        now = pd.Timestamp("2026-04-10 03:00:00", tz="UTC")
+        assert _current_dayobs_utc(now) == 20260409
+
+    def test_exactly_at_noon_utc_returns_same_date(self):
+        now = pd.Timestamp("2026-04-09 12:00:00", tz="UTC")
+        assert _current_dayobs_utc(now) == 20260409
+
+    def test_one_second_before_noon_returns_previous_date(self):
+        now = pd.Timestamp("2026-04-09 11:59:59", tz="UTC")
+        assert _current_dayobs_utc(now) == 20260408
+
+    def test_month_boundary(self):
+        now = pd.Timestamp("2026-05-01 03:00:00", tz="UTC")
+        assert _current_dayobs_utc(now) == 20260430
+
+    def test_year_boundary(self):
+        now = pd.Timestamp("2027-01-01 03:00:00", tz="UTC")
+        assert _current_dayobs_utc(now) == 20261231
+
+
+# ---------------------------------------------------------------------------
+# _compute_closed_hours (operates on aggregated per-night rows)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeClosedHoursPastNight:
+    def test_dome_did_not_open(self):
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=0.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+    def test_dome_open_for_full_night(self):
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=11.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(0.0)
+
+    def test_dome_open_for_partial_night(self):
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=6.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(5.0)
+
+    def test_multiple_sessions_aggregated_open_hours_sum(self):
+        # Two sessions (3hrs + 2hrs = 5hrs) on a past night.
+        # The groupby already summed them; _compute_closed_hours just
+        # sees the total.
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=5.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(6.0)
+
+    def test_past_session_then_closed_then_second_session(self):
+        # Dome opened 2hrs, closed 1hr, opened again 3hrs = 5hrs total open.
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=5.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(6.0)
+
+    def test_night_with_only_non_science_exposures(self):
+        # Dome open/close is independent of exposure type.
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, open_hours=4.0, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(7.0)
+
+
+class TestComputeClosedHoursCurrentNight:
+    def test_dome_not_yet_opened_uses_elapsed_since_sunset(self):
+        # 2hrs into the night, dome still closed.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=0.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(2.0)
+
+    def test_single_open_session_currently_active(self):
+        # Dome has been open for 3hrs (rubin-nights tracks elapsed open
+        # time for an active session). closed = night_hours - open_hours.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=3.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=5)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 3.0)
+
+    def test_past_closed_session_then_current_open_session(self):
+        # Session 1: dome open 1hr, closed 1hr. Session 2: currently open 3hrs.
+        # Aggregated open_hours = 1 + 3 = 4.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=4.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=6)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 4.0)
+
+    def test_multiple_past_open_sessions_no_current_open(self):
+        # Two completed sessions (2hrs + 1.5hrs = 3.5hrs), dome now closed.
+        # Because open_hours > 0, use night_hours - open_hours.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=3.5, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=7)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS - 3.5)
+
+    def test_just_after_evening_twilight_dome_closed(self):
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=0.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(minutes=1)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(1 / 60)
+
+
+class TestComputeClosedHoursEdgeCases:
+    def test_future_night_not_yet_started(self):
+        # now_utc is before sunset12 for a future dayobs -- not in progress,
+        # falls back to night_hours - open_hours (both 0 for a future night).
+        row = make_aggregated_row(
+            day_obs=NEXT_DAYOBS,
+            sunset12=pd.Timestamp("2026-04-10 23:00:00", tz="UTC"),
+            sunrise12=pd.Timestamp("2026-04-11 10:00:00", tz="UTC"),
+            open_hours=0.0,
+            night_hours=11.0,
+        )
+        now_utc = SUNSET12 + timedelta(hours=1)  # still in previous night
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+    def test_nat_sunset12_falls_back_to_past_night_branch(self):
+        row = make_aggregated_row(
+            day_obs=DAYOBS,
+            sunset12=pd.NaT,
+            open_hours=0.0,
+            night_hours=11.0,
+        )
+        now_utc = SUNSET12 + timedelta(hours=3)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+    def test_nat_sunrise12_falls_back_to_past_night_branch(self):
+        row = make_aggregated_row(
+            day_obs=DAYOBS,
+            sunrise12=pd.NaT,
+            open_hours=0.0,
+            night_hours=11.0,
+        )
+        now_utc = SUNSET12 + timedelta(hours=3)
+        assert _compute_closed_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+
+# ---------------------------------------------------------------------------
+# _elapsed_night_hours
+# ---------------------------------------------------------------------------
+
+
+class TestElapsedNightHours:
+    def test_past_night_returns_full_night_hours(self):
+        row = make_aggregated_row(day_obs=PREV_DAYOBS, night_hours=11.0)
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+    def test_current_night_in_progress_returns_elapsed(self):
+        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=3)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(3.0)
+
+    def test_current_night_just_started(self):
+        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(minutes=30)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(0.5)
+
+    def test_future_night_returns_full_night_hours(self):
+        row = make_aggregated_row(
+            day_obs=NEXT_DAYOBS,
+            sunset12=pd.Timestamp("2026-04-10 23:00:00", tz="UTC"),
+            sunrise12=pd.Timestamp("2026-04-11 10:00:00", tz="UTC"),
+            night_hours=11.0,
+        )
+        now_utc = SUNSET12 + timedelta(hours=2)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(11.0)
+
+    def test_now_before_sunset12_on_current_dayobs_returns_full_night_hours(self):
+        # Current dayobs but before the night has started -- not in progress.
+        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 - timedelta(hours=1)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
+
+    def test_nat_sunset12_falls_back_to_full_night_hours(self):
+        row = make_aggregated_row(day_obs=DAYOBS, sunset12=pd.NaT, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=3)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
+
+    def test_elapsed_never_exceeds_night_hours(self):
+        # now_utc is past sunrise -- still returns elapsed since sunset,
+        # but the night_in_progress condition (now <= sunrise12) is False,
+        # so it returns night_hours instead.
+        row = make_aggregated_row(day_obs=DAYOBS, night_hours=NIGHT_HOURS)
+        now_utc = SUNRISE12 + timedelta(hours=2)
+        assert _elapsed_night_hours(row, DAYOBS, now_utc) == pytest.approx(NIGHT_HOURS)
+
+    def test_elapsed_is_consistent_with_closed_hours_when_dome_closed(self):
+        # When the dome never opened, elapsed_night_hours - 0 open_hours
+        # should equal closed_hours for a night in progress.
+        row = make_aggregated_row(day_obs=DAYOBS, open_hours=0.0, night_hours=NIGHT_HOURS)
+        now_utc = SUNSET12 + timedelta(hours=4)
+        elapsed = _elapsed_night_hours(row, DAYOBS, now_utc)
+        closed = _compute_closed_hours(row, DAYOBS, now_utc)
+        assert elapsed == pytest.approx(closed)
+
+
+# ---------------------------------------------------------------------------
+# get_open_close_dome (raw per-session return, no closed_hours)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_clients():
+    with patch(f"{MODULE}.get_clients") as mock_get_clients:
+        mock_get_clients.return_value = {"efd": MagicMock()}
+        yield mock_get_clients
+
+
+class TestGetOpenCloseDome:
+    def test_single_session_night_returned(self, mock_clients):
+        raw = make_raw_dome_df({"day_obs": DAYOBS, "open_hours": 5.5})
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert len(result) == 1
+        assert result.iloc[0]["day_obs"] == DAYOBS
+
+    def test_multiple_sessions_same_night_both_rows_returned(self, mock_clients):
+        # Two sessions on the same night -- both rows should be present
+        # since closed_hours is not computed here; aggregation happens
+        # in the endpoint groupby.
+        raw = make_raw_dome_df(
+            {
+                "day_obs": DAYOBS,
+                "open_hours": 3.0,
+                "open_time": pd.Timestamp("2026-04-09 23:30:00"),
+                "close_time": pd.Timestamp("2026-04-10 02:30:00"),
+            },
+            {
+                "day_obs": DAYOBS,
+                "open_hours": 2.0,
+                "open_time": pd.Timestamp("2026-04-10 04:00:00"),
+                "close_time": pd.Timestamp("2026-04-10 06:00:00"),
+            },
+        )
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert len(result) == 2
+        assert (result["day_obs"] == DAYOBS).all()
+
+    def test_closed_night_no_sessions_returned(self, mock_clients):
+        # get_dome_open_close now guarantees an entry even for closed nights.
+        raw = make_raw_dome_df({"day_obs": DAYOBS, "open_hours": 0.0, "open_time": None, "close_time": None})
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert len(result) == 1
+        assert result.iloc[0]["open_hours"] == 0.0
+
+    def test_closed_hours_not_in_raw_output(self, mock_clients):
+        # closed_hours belongs on the aggregated per-night result,
+        # not the per-session rows.
+        raw = make_raw_dome_df({"day_obs": DAYOBS, "open_hours": 5.5})
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert "closed_hours" not in result.columns
+
+    def test_day_obs_as_index_normalised_to_column(self, mock_clients):
+        raw = make_raw_dome_df({"day_obs": DAYOBS}).set_index("day_obs")
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert "day_obs" in result.columns
+        assert result.index.name != "day_obs"
+
+    def test_multiple_nights_each_session_preserved(self, mock_clients):
+        raw = make_raw_dome_df(
+            {"day_obs": PREV_DAYOBS, "open_hours": 4.0},
+            {"day_obs": DAYOBS, "open_hours": 3.0},
+            {"day_obs": DAYOBS, "open_hours": 2.0},  # second session same night
+        )
+        with patch(f"{MODULE}.get_dome_open_close", return_value=raw):
+            result = get_open_close_dome(PREV_DAYOBS, NEXT_DAYOBS, "lsstcam")
+        assert len(result) == 3
+        assert len(result[result["day_obs"] == DAYOBS]) == 2
+        assert len(result[result["day_obs"] == PREV_DAYOBS]) == 1

--- a/tests/test_get_time_accounting.py
+++ b/tests/test_get_time_accounting.py
@@ -1,0 +1,476 @@
+# tests/test_time_accounting.py
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service import (
+    _compute_filter_changed,
+    _obs_start_tai_to_utc_ms,
+    _sum_on_sky_within_twilight,
+    _twilight_windows_by_dayobs,
+    get_time_accounting,
+)
+
+MODULE = "lsst.ts.logging_and_reporting.web_app.services.rubin_nights_service"
+TWILIGHT_SUM_KEYS = (
+    "sum_overhead_with_filter_change",
+    "sum_overhead_without_filter_change",
+    "sum_visit_gap_with_filter_change",
+    "sum_visit_gap_without_filter_change",
+)
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+# A single night: dayobs 20260409, twilights in UTC (naive strings,
+# as get_almanac returns them).
+ALMANAC_INFO = [
+    {
+        "dayobs": 20260410,  # labeled with morning twilight date
+        "night_hours": 11.0,
+        "twilight_evening_12deg": "2026-04-09 23:00:00",
+        "twilight_morning_12deg": "2026-04-10 10:00:00",
+    }
+]
+
+# TAI is UTC + 37s. obs_start values below are TAI ISO strings.
+TAI_OFFSET_MS = 37_000  # 37 seconds in milliseconds
+
+EVENING_12DEG_UTC_MS = int(pd.Timestamp("2026-04-09 23:00:00", tz="UTC").timestamp() * 1000)
+MORNING_12DEG_UTC_MS = int(pd.Timestamp("2026-04-10 10:00:00", tz="UTC").timestamp() * 1000)
+
+# obs_start in TAI that lands inside the twilight window when converted to UTC
+OBS_START_IN_WINDOW_TAI = "2026-04-10T01:00:37.000000"  # UTC 01:00:00 → inside
+OBS_START_BEFORE_WINDOW_TAI = "2026-04-09T22:59:37.000000"  # UTC 22:59:00 → before evening
+OBS_START_AFTER_WINDOW_TAI = "2026-04-10T10:00:38.000000"  # UTC 10:00:01 → after morning
+
+
+def make_visit(**kwargs) -> dict:
+    """Minimal visit row with sensible defaults."""
+    defaults = {
+        "obs_start": OBS_START_IN_WINDOW_TAI,
+        "day_obs": 20260409,
+        "can_see_sky": True,
+        "band": "r",
+        "physical_filter": "r_57",
+        "overhead": 3600.0,  # 1 hour in seconds
+        "visit_gap": 7200.0,  # 2 hours in seconds
+    }
+    return {**defaults, **kwargs}
+
+
+def make_visits_df(*rows) -> pd.DataFrame:
+    if not rows:
+        rows = ({},)
+    return pd.DataFrame([make_visit(**r) for r in rows])
+
+
+# ---------------------------------------------------------------------------
+# _twilight_windows_by_dayobs
+# ---------------------------------------------------------------------------
+
+
+class TestTwilightWindowsByDayobs:
+    def test_maps_to_visit_dayobs_not_almanac_dayobs(self):
+        windows = _twilight_windows_by_dayobs(ALMANAC_INFO)
+        # Almanac labels by morning twilight date (20260410),
+        # but visits on that night carry day_obs 20260409.
+        assert 20260409 in windows
+        assert 20260410 not in windows
+
+    def test_window_start_is_evening_twilight_ms(self):
+        windows = _twilight_windows_by_dayobs(ALMANAC_INFO)
+        start_ms, _ = windows[20260409]
+        assert start_ms == EVENING_12DEG_UTC_MS
+
+    def test_window_end_is_morning_twilight_ms(self):
+        windows = _twilight_windows_by_dayobs(ALMANAC_INFO)
+        _, end_ms = windows[20260409]
+        assert end_ms == MORNING_12DEG_UTC_MS
+
+    def test_multiple_nights(self):
+        almanac = ALMANAC_INFO + [
+            {
+                "dayobs": 20260411,
+                "night_hours": 11.0,
+                "twilight_evening_12deg": "2026-04-10 23:00:00",
+                "twilight_morning_12deg": "2026-04-11 10:00:00",
+            }
+        ]
+        windows = _twilight_windows_by_dayobs(almanac)
+        assert set(windows.keys()) == {20260409, 20260410}
+
+
+# ---------------------------------------------------------------------------
+# _obs_start_tai_to_utc_ms
+# ---------------------------------------------------------------------------
+
+
+class TestObsStartTaiToUtcMs:
+    def test_tai_offset_applied(self):
+        # TAI is 37s ahead of UTC; converting to UTC should subtract 37s.
+        tai_series = pd.Series(["2026-04-10T01:00:37.000000"])
+        result = _obs_start_tai_to_utc_ms(tai_series)
+        expected_ms = int(pd.Timestamp("2026-04-10 01:00:00", tz="UTC").timestamp() * 1000)
+        assert result.iloc[0] == pytest.approx(expected_ms, abs=1000)
+
+    def test_null_values_produce_nan(self):
+        tai_series = pd.Series([None, "2026-04-10T01:00:37.000000"])
+        result = _obs_start_tai_to_utc_ms(tai_series)
+        assert pd.isna(result.iloc[0])
+        assert pd.notna(result.iloc[1])
+
+    def test_all_null_returns_all_nan(self):
+        tai_series = pd.Series([None, None])
+        result = _obs_start_tai_to_utc_ms(tai_series)
+        assert result.isna().all()
+
+    def test_empty_series(self):
+        result = _obs_start_tai_to_utc_ms(pd.Series([], dtype=object))
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# _compute_filter_changed
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# _compute_filter_changed
+# (expects visits_sorted -- already ordered by obs_start)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFilterChanged:
+    def test_first_visit_is_never_a_change(self):
+        df = make_visits_df({"band": "r", "physical_filter": "r_57"})
+        result = _compute_filter_changed(df)
+        assert not result.iloc[0]
+
+    def test_same_band_consecutive_visits_no_change(self):
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:00:00", "band": "r", "physical_filter": "r_57"},
+            {"obs_start": "2026-04-10T01:01:00", "band": "r", "physical_filter": "r_57"},
+        )
+        result = _compute_filter_changed(df)
+        assert not result.iloc[1]
+
+    def test_band_change_is_flagged(self):
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:00:00", "band": "r", "physical_filter": "r_57"},
+            {"obs_start": "2026-04-10T01:01:00", "band": "g", "physical_filter": "g_6"},
+        )
+        result = _compute_filter_changed(df)
+        assert result.iloc[1]
+
+    def test_physical_filter_change_with_same_band_not_flagged(self):
+        # _compute_filter_changed only checks band, not physical_filter.
+        # Two different physical filters in the same band are not a change.
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:00:00", "band": "r", "physical_filter": "r_57"},
+            {"obs_start": "2026-04-10T01:01:00", "band": "r", "physical_filter": "r_58"},
+        )
+        result = _compute_filter_changed(df)
+        assert not result.iloc[1]
+
+    def test_expects_pre_sorted_input(self):
+        # _compute_filter_changed does not sort -- it uses shift(1) on
+        # whatever order the DataFrame arrives in. The sort responsibility
+        # lives in _sum_on_sky_within_twilight. Passing unsorted input
+        # produces wrong results, which is intentional by design.
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:01:00", "band": "g", "physical_filter": "g_6"},
+            {"obs_start": "2026-04-10T01:00:00", "band": "r", "physical_filter": "r_57"},
+        )
+        result = _compute_filter_changed(df)
+        # With unsorted input, row 0 (g) is first -- no change.
+        # Row 1 (r after g) -- flagged as change.
+        assert not result.iloc[0]
+        assert result.iloc[1]
+
+    def test_nan_band_to_non_nan_counts_as_change(self):
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:00:00", "band": None, "physical_filter": "r_57"},
+            {"obs_start": "2026-04-10T01:01:00", "band": "r", "physical_filter": "r_57"},
+        )
+        result = _compute_filter_changed(df)
+        assert result.iloc[1]
+
+    def test_nan_to_nan_does_not_count_as_change(self):
+        df = make_visits_df(
+            {"obs_start": "2026-04-10T01:00:00", "band": None, "physical_filter": None},
+            {"obs_start": "2026-04-10T01:01:00", "band": None, "physical_filter": None},
+        )
+        result = _compute_filter_changed(df)
+        assert not result.iloc[1]
+
+    def test_single_visit_returns_false(self):
+        df = make_visits_df({})
+        result = _compute_filter_changed(df)
+        assert len(result) == 1
+        assert not result.iloc[0]
+
+
+# ---------------------------------------------------------------------------
+# _sum_on_sky_within_twilight
+# (owns the sort -- this is where time-order tests belong)
+# ---------------------------------------------------------------------------
+
+
+class TestSumOnSkyWithinTwilight:
+    def test_returns_all_four_keys(self):
+        df = make_visits_df()
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert set(result.keys()) == {
+            "sum_overhead_with_filter_change",
+            "sum_overhead_without_filter_change",
+            "sum_visit_gap_with_filter_change",
+            "sum_visit_gap_without_filter_change",
+        }
+
+    def test_all_values_are_floats(self):
+        df = make_visits_df()
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert all(isinstance(v, float) for v in result.values())
+
+    def test_values_rounded_to_two_decimal_places(self):
+        # 3601s / 3600 = 1.000277... → rounds to 1.0
+        df = make_visits_df({"overhead": 3601.0, "visit_gap": 3601.0})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        for v in result.values():
+            assert v == round(v, 2)
+
+    def test_visit_before_evening_twilight_excluded(self):
+        df = make_visits_df({"obs_start": OBS_START_BEFORE_WINDOW_TAI, "can_see_sky": True})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_visit_after_morning_twilight_excluded(self):
+        df = make_visits_df({"obs_start": OBS_START_AFTER_WINDOW_TAI, "can_see_sky": True})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_can_see_sky_false_excluded(self):
+        df = make_visits_df({"can_see_sky": False})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_sums_converted_to_hours(self):
+        df = make_visits_df({"overhead": 3600.0, "visit_gap": 7200.0})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(1.0)
+        assert result["sum_visit_gap_without_filter_change"] == pytest.approx(2.0)
+
+    def test_sort_is_applied_before_filter_change_detection(self):
+        # DataFrame arrives in reverse time order. Without an internal sort,
+        # the second visit (r→g) would be compared against g, not r, and
+        # would be wrongly flagged as no-change. The sort in
+        # _sum_on_sky_within_twilight must fire before _compute_filter_changed.
+        df = make_visits_df(
+            {
+                "obs_start": "2026-04-10T02:00:37.000",
+                "band": "g",
+                "physical_filter": "g_6",
+                "overhead": 1800.0,
+                "visit_gap": 3600.0,
+                "can_see_sky": True,
+            },
+            {
+                "obs_start": "2026-04-10T01:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 3600.0,
+                "visit_gap": 7200.0,
+                "can_see_sky": True,
+            },
+        )
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        # After sorting: r is first (no change), g is second (band change).
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(round(3600 / 3600, 2))
+        assert result["sum_overhead_with_filter_change"] == pytest.approx(round(1800 / 3600, 2))
+
+    def test_same_band_consecutive_goes_to_without_change_bucket(self):
+        df = make_visits_df(
+            {
+                "obs_start": "2026-04-10T01:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 3600.0,
+                "visit_gap": 7200.0,
+            },
+            {
+                "obs_start": "2026-04-10T02:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 1800.0,
+                "visit_gap": 3600.0,
+            },
+        )
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(round((3600 + 1800) / 3600, 2))
+        assert result["sum_overhead_with_filter_change"] == pytest.approx(0.0)
+
+    def test_band_change_goes_to_with_change_bucket(self):
+        df = make_visits_df(
+            {
+                "obs_start": "2026-04-10T01:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 3600.0,
+                "visit_gap": 7200.0,
+            },
+            {
+                "obs_start": "2026-04-10T02:00:37.000",
+                "band": "g",
+                "physical_filter": "g_6",
+                "overhead": 1800.0,
+                "visit_gap": 3600.0,
+            },
+        )
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(round(3600 / 3600, 2))
+        assert result["sum_overhead_with_filter_change"] == pytest.approx(round(1800 / 3600, 2))
+        assert result["sum_visit_gap_without_filter_change"] == pytest.approx(round(7200 / 3600, 2))
+        assert result["sum_visit_gap_with_filter_change"] == pytest.approx(round(3600 / 3600, 2))
+
+    def test_physical_filter_change_same_band_stays_in_without_change_bucket(self):
+        # band is the only discriminator -- physical_filter alone doesn't
+        # trigger the with_change bucket.
+        df = make_visits_df(
+            {
+                "obs_start": "2026-04-10T01:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 3600.0,
+                "visit_gap": 7200.0,
+            },
+            {
+                "obs_start": "2026-04-10T02:00:37.000",
+                "band": "r",
+                "physical_filter": "r_58",
+                "overhead": 1800.0,
+                "visit_gap": 3600.0,
+            },
+        )
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert result["sum_overhead_with_filter_change"] == pytest.approx(0.0)
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(round((3600 + 1800) / 3600, 2))
+
+    def test_nan_overhead_treated_as_zero(self):
+        df = make_visits_df({"overhead": None, "visit_gap": 3600.0})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert result["sum_overhead_without_filter_change"] == pytest.approx(0.0)
+        assert result["sum_visit_gap_without_filter_change"] == pytest.approx(1.0)
+
+    def test_unknown_dayobs_excluded(self):
+        df = make_visits_df({"day_obs": 99990101, "can_see_sky": True})
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_with_and_without_buckets_sum_to_total(self):
+        df = make_visits_df(
+            {
+                "obs_start": "2026-04-10T01:00:37.000",
+                "band": "r",
+                "physical_filter": "r_57",
+                "overhead": 3600.0,
+                "visit_gap": 7200.0,
+            },
+            {
+                "obs_start": "2026-04-10T02:00:37.000",
+                "band": "g",
+                "physical_filter": "g_6",
+                "overhead": 1800.0,
+                "visit_gap": 900.0,
+            },
+        )
+        result = _sum_on_sky_within_twilight(df, ALMANAC_INFO)
+        total_overhead = (
+            result["sum_overhead_with_filter_change"] + result["sum_overhead_without_filter_change"]
+        )
+        total_gap = result["sum_visit_gap_with_filter_change"] + result["sum_visit_gap_without_filter_change"]
+        assert total_overhead == pytest.approx(round((3600 + 1800) / 3600, 2))
+        assert total_gap == pytest.approx(round((7200 + 900) / 3600, 2))
+
+
+# ---------------------------------------------------------------------------
+# get_time_accounting
+# ---------------------------------------------------------------------------
+
+MOCK_ALMANAC = ALMANAC_INFO
+
+MOCK_VISITS_DF = make_visits_df(
+    {
+        "obs_start": OBS_START_IN_WINDOW_TAI,
+        "band": "r",
+        "physical_filter": "r_57",
+        "overhead": 3600.0,
+        "visit_gap": 7200.0,
+        "can_see_sky": True,
+    },
+)
+
+
+@pytest.fixture
+def mock_time_accounting_deps():
+    """Mock all external calls inside get_time_accounting."""
+
+    def mock_augment_visits(exposures_df, instrument, skip_rs_columns=True):
+        visits = exposures_df.copy()
+        visits["slew_model"] = 5.0
+        return visits
+
+    def mock_add_model_slew_times(visits, efd, model_settle, dome_crawl=False):
+        return visits.copy(), None
+
+    with (
+        patch(f"{MODULE}.get_clients", return_value={"efd": MagicMock()}),
+        patch(f"{MODULE}.rn_aug.augment_visits", side_effect=mock_augment_visits),
+        patch(f"{MODULE}.rn_sch.add_model_slew_times", side_effect=mock_add_model_slew_times),
+        patch(f"{MODULE}.get_almanac", return_value=MOCK_ALMANAC),
+    ):
+        yield
+
+
+class TestGetTimeAccounting:
+    def test_empty_exposures_returns_zero_sums(self):
+        result = get_time_accounting(20260409, 20260410, "lsstcam", [])
+        assert set(result.keys()) == set(TWILIGHT_SUM_KEYS)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_empty_exposures_does_not_call_external_services(self):
+        with patch(f"{MODULE}.get_clients") as mock_clients:
+            get_time_accounting(20260409, 20260410, "lsstcam", [])
+            mock_clients.assert_not_called()
+
+    def test_returns_all_four_keys(self, mock_time_accounting_deps):
+        exposures = [make_visit()]
+        result = get_time_accounting(20260409, 20260410, "lsstcam", exposures)
+        assert set(result.keys()) == set(TWILIGHT_SUM_KEYS)
+
+    def test_all_values_are_floats(self, mock_time_accounting_deps):
+        exposures = [make_visit()]
+        result = get_time_accounting(20260409, 20260410, "lsstcam", exposures)
+        assert all(isinstance(v, float) for v in result.values())
+
+    def test_non_on_sky_exposures_produce_zero_sums(self, mock_time_accounting_deps):
+        exposures = [make_visit(can_see_sky=False)]
+        result = get_time_accounting(20260409, 20260410, "lsstcam", exposures)
+        assert all(v == 0.0 for v in result.values())
+
+    def test_almanac_called_with_correct_dayobs_end(self, mock_time_accounting_deps):
+        # almanac_dayobs_end should be dayObsEnd + 1 day.
+        mock_visits = MOCK_VISITS_DF.copy()
+        mock_visits["slew_model"] = 5.0
+
+        with patch(f"{MODULE}.get_almanac", return_value=MOCK_ALMANAC) as mock_almanac:
+            with patch(f"{MODULE}.rn_aug.augment_visits", return_value=mock_visits.copy()):
+                with patch(
+                    f"{MODULE}.rn_sch.add_model_slew_times",
+                    return_value=(mock_visits.copy(), None),
+                ):
+                    get_time_accounting(20260409, 20260410, "lsstcam", [make_visit()])
+        call_args = mock_almanac.call_args
+        assert call_args[0][0] == 20260409  # dayObsStart unchanged
+        assert call_args[0][1] == 20260411  # dayObsEnd + 1


### PR DESCRIPTION
Simply frontend dome times and time accounting calculations by doing them in the backend and utilising the aggregations introduced in `rubin-nights > 0.10
`Refactor the endpoint for better error reporting and handling

This PR is dependent on  `rubin-nights` version `0.18.1`  to get dome sessions in the format that the ND expects.