### PR TITLE
OSW-2415: Add CacheControlMiddleware for HTTP-layer caching

### DIFF
--- a/doc/news/OSW-2415.perf.rst
+++ b/doc/news/OSW-2415.perf.rst
@@ -1,2 +1,1 @@
-Added ``CacheControlMiddleware`` to set ``Cache-Control`` response headers,
-enabling caching at the browser and nginx proxy layers.
+Added ``CacheControlMiddleware`` to set ``Cache-Control`` response headers, enabling caching at the browser and nginx proxy layers.

--- a/doc/news/OSW-2415.perf.rst
+++ b/doc/news/OSW-2415.perf.rst
@@ -1,0 +1,2 @@
+Added ``CacheControlMiddleware`` to set ``Cache-Control`` response headers,
+enabling caching at the browser and nginx proxy layers.

--- a/python/lsst/ts/logging_and_reporting/web_app/main.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/main.py
@@ -43,6 +43,7 @@ from lsst.ts.logging_and_reporting.utils import (
 )
 
 from .. import __version__
+from .middleware import CacheControlMiddleware
 from .services.almanac_service import get_almanac
 from .services.consdb_service import (
     get_data_log,
@@ -92,6 +93,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(CacheControlMiddleware)
 
 
 logger.info("Starting FastAPI app")

--- a/python/lsst/ts/logging_and_reporting/web_app/middleware/__init__.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .cache_control import CacheControlMiddleware
+
+__all__ = ["CacheControlMiddleware"]

--- a/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
@@ -1,0 +1,97 @@
+#
+# This file is part of ts_logging_and_reporting.
+#
+# Developed for Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+# Short TTL for responses that include today (matches RefreshWorker interval)
+_TODAY_MAX_AGE = 300
+# Long TTL for fully historical responses
+_HISTORICAL_MAX_AGE = 86400
+
+
+def _today_dayobs() -> int:
+    """Return the current astronomical dayobs as an integer YYYYMMDD.
+
+    A dayobs runs noon-to-noon UTC, so subtracting 12 hours and taking
+    the date gives the correct dayobs for any UTC timestamp.
+    """
+    now_utc = datetime.now(tz=timezone.utc)
+    return int((now_utc - timedelta(hours=12)).strftime("%Y%m%d"))
+
+
+class CacheControlMiddleware(BaseHTTPMiddleware):
+    """Set ``Cache-Control`` headers based on the requested dayobs range.
+
+    Endpoints that accept dayobs query parameters receive a
+    ``Cache-Control: max-age=<N>`` header.  The value of ``max-age`` is:
+
+    - ``300`` (short) if the response includes today's astronomical dayobs,
+      so proxy and browser caches never serve data more stale than one
+      ``RefreshWorker`` cycle.
+    - ``86400`` (long) for fully historical requests whose data will not
+      change.
+
+    Endpoints without dayobs parameters (``/version``, ``/health``,
+    ``/block-details``) are left untouched.
+
+    Query parameter names handled:
+
+    - ``dayObs`` — single-day endpoints (e.g. ``/survey-progress-map``)
+    - ``dayObsStart`` + ``dayObsEnd`` — range endpoints (all others)
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+
+        params = request.query_params
+
+        day_obs_raw = params.get("dayObs")
+        start_raw = params.get("dayObsStart")
+        end_raw = params.get("dayObsEnd")
+
+        # Single dayObs implies a one-day range
+        if day_obs_raw and not (start_raw or end_raw):
+            start_raw = day_obs_raw
+            end_raw = day_obs_raw
+
+        if not (start_raw or end_raw):
+            return response
+
+        try:
+            start = int(start_raw) if start_raw else None
+            end = int(end_raw) if end_raw else None
+        except (ValueError, TypeError):
+            print("There's an error getting start/end dayobs")
+            return response
+
+        # If only one bound is present, treat it as both
+        start = start if start is not None else end
+        end = end if end is not None else start
+
+        today = _today_dayobs()
+        max_age = _TODAY_MAX_AGE if start <= today <= end else _HISTORICAL_MAX_AGE
+
+        response.headers["Cache-Control"] = f"public, max-age={max_age}"
+        return response

--- a/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
@@ -30,6 +30,17 @@ _TODAY_MAX_AGE = 300
 # Long TTL for fully historical responses
 _HISTORICAL_MAX_AGE = 86400
 
+# Endpoints that always receive the short TTL because they contain mutable
+# data regardless of which dayobs is requested.
+_ALWAYS_SHORT_PATHS = frozenset(
+    {
+        "/exposure-flags",
+        "/block-details",
+        "/exposure-entries",
+        "/narrative-log",
+    }
+)
+
 
 def _today_dayobs() -> int:
     """Return the current astronomical dayobs as an integer YYYYMMDD.
@@ -53,8 +64,12 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     - ``86400`` (long) for fully historical requests whose data will not
       change.
 
-    Endpoints without dayobs parameters (``/version``, ``/health``,
-    ``/block-details``) are left untouched.
+    Endpoints without dayobs parameters (``/version``, ``/health``)
+    are left untouched.
+
+    Some endpoints (``/exposure-flags``, ``/block-details``,
+    ``/exposure-entries``, ``/narrative-log``) always receive the short
+    TTL because they contain mutable data regardless of dayobs.
 
     Query parameter names handled:
 
@@ -64,6 +79,13 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next) -> Response:
         response = await call_next(request)
+
+        path = request.url.path.rstrip("/")
+
+        # Mutable-data endpoints always get the short TTL.
+        if path in _ALWAYS_SHORT_PATHS:
+            response.headers["Cache-Control"] = f"public, max-age={_TODAY_MAX_AGE}"
+            return response
 
         params = request.query_params
 

--- a/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
+++ b/python/lsst/ts/logging_and_reporting/web_app/middleware/cache_control.py
@@ -20,12 +20,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from datetime import datetime, timedelta, timezone
+import logging
+from datetime import datetime, timezone
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
-# Short TTL for responses that include today (matches RefreshWorker interval)
+from lsst.ts.logging_and_reporting.utils import current_dayobs_utc
+
+logger = logging.getLogger("uvicorn.error")
+
+# Short TTL for responses that include today
+# Matches RefreshWorker interval - see doc/BACKEND_REFACTOR_PLAN.md
 _TODAY_MAX_AGE = 300
 # Long TTL for fully historical responses
 _HISTORICAL_MAX_AGE = 86400
@@ -38,18 +44,9 @@ _ALWAYS_SHORT_PATHS = frozenset(
         "/block-details",
         "/exposure-entries",
         "/narrative-log",
+        "/jira-tickets",
     }
 )
-
-
-def _today_dayobs() -> int:
-    """Return the current astronomical dayobs as an integer YYYYMMDD.
-
-    A dayobs runs noon-to-noon UTC, so subtracting 12 hours and taking
-    the date gives the correct dayobs for any UTC timestamp.
-    """
-    now_utc = datetime.now(tz=timezone.utc)
-    return int((now_utc - timedelta(hours=12)).strftime("%Y%m%d"))
 
 
 class CacheControlMiddleware(BaseHTTPMiddleware):
@@ -67,8 +64,7 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
     Endpoints without dayobs parameters (``/version``, ``/health``)
     are left untouched.
 
-    Some endpoints (``/exposure-flags``, ``/block-details``,
-    ``/exposure-entries``, ``/narrative-log``) always receive the short
+    Some endpoints (see _ALWAYS_SHORT_PATHS) always receive the short
     TTL because they contain mutable data regardless of dayobs.
 
     Query parameter names handled:
@@ -105,14 +101,14 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
             start = int(start_raw) if start_raw else None
             end = int(end_raw) if end_raw else None
         except (ValueError, TypeError):
-            print("There's an error getting start/end dayobs")
+            logger.error("There's an error getting start/end dayobs")
             return response
 
         # If only one bound is present, treat it as both
         start = start if start is not None else end
         end = end if end is not None else start
 
-        today = _today_dayobs()
+        today = current_dayobs_utc(datetime.now(timezone.utc))
         max_age = _TODAY_MAX_AGE if start <= today <= end else _HISTORICAL_MAX_AGE
 
         response.headers["Cache-Control"] = f"public, max-age={max_age}"

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -81,7 +81,7 @@ def _cache_header(response):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_historical_range_gets_long_ttl(mock_today, client):
@@ -90,7 +90,7 @@ def test_historical_range_gets_long_ttl(mock_today, client):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_range_including_today_gets_short_ttl(mock_today, client):
@@ -102,7 +102,7 @@ def test_range_including_today_gets_short_ttl(mock_today, client):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_single_dayobs_today_gets_short_ttl(mock_today, client):
@@ -111,7 +111,7 @@ def test_single_dayobs_today_gets_short_ttl(mock_today, client):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_single_dayobs_historical_gets_long_ttl(mock_today, client):
@@ -132,7 +132,7 @@ def test_no_dayobs_params_no_cache_header(client):
 
 @pytest.mark.parametrize("path", sorted(_ALWAYS_SHORT_PATHS))
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_always_short_paths_get_short_ttl(mock_today, path, client):
@@ -155,7 +155,7 @@ def test_invalid_dayobs_no_cache_header(client):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_only_start_param(mock_today, client):
@@ -164,7 +164,7 @@ def test_only_start_param(mock_today, client):
 
 
 @patch(
-    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control.current_dayobs_utc",
     return_value=MOCK_TODAY,
 )
 def test_only_end_param(mock_today, client):

--- a/tests/test_cache_control.py
+++ b/tests/test_cache_control.py
@@ -1,0 +1,172 @@
+#
+# This file is part of ts_logging_and_reporting.
+#
+# Developed for Vera C. Rubin Observatory Telescope and Site Systems.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from lsst.ts.logging_and_reporting.web_app.middleware.cache_control import (
+    _ALWAYS_SHORT_PATHS,
+    _HISTORICAL_MAX_AGE,
+    _TODAY_MAX_AGE,
+    CacheControlMiddleware,
+)
+
+MOCK_TODAY = 20260101
+
+
+def _make_app():
+    """Create a minimal FastAPI app with the cache middleware."""
+    app = FastAPI()
+    app.add_middleware(CacheControlMiddleware)
+
+    @app.get("/some-endpoint")
+    def some_endpoint():
+        return {"ok": True}
+
+    @app.get("/exposure-flags")
+    def exposure_flags():
+        return {"ok": True}
+
+    @app.get("/block-details")
+    def block_details():
+        return {"ok": True}
+
+    @app.get("/exposure-entries")
+    def exposure_entries():
+        return {"ok": True}
+
+    @app.get("/narrative-log")
+    def narrative_log():
+        return {"ok": True}
+
+    @app.get("/health")
+    def health():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture()
+def client():
+    return TestClient(_make_app())
+
+
+def _cache_header(response):
+    return response.headers.get("Cache-Control")
+
+
+# -- dayobs-based caching --
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_historical_range_gets_long_ttl(mock_today, client):
+    resp = client.get("/some-endpoint", params={"dayObsStart": 20250101, "dayObsEnd": 20250131})
+    assert _cache_header(resp) == f"public, max-age={_HISTORICAL_MAX_AGE}"
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_range_including_today_gets_short_ttl(mock_today, client):
+    resp = client.get(
+        "/some-endpoint",
+        params={"dayObsStart": 20251201, "dayObsEnd": 20260201},
+    )
+    assert _cache_header(resp) == f"public, max-age={_TODAY_MAX_AGE}"
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_single_dayobs_today_gets_short_ttl(mock_today, client):
+    resp = client.get("/some-endpoint", params={"dayObs": MOCK_TODAY})
+    assert _cache_header(resp) == f"public, max-age={_TODAY_MAX_AGE}"
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_single_dayobs_historical_gets_long_ttl(mock_today, client):
+    resp = client.get("/some-endpoint", params={"dayObs": 20250601})
+    assert _cache_header(resp) == f"public, max-age={_HISTORICAL_MAX_AGE}"
+
+
+# -- no dayobs params → no header --
+
+
+def test_no_dayobs_params_no_cache_header(client):
+    resp = client.get("/health")
+    assert _cache_header(resp) is None
+
+
+# -- always-short-path endpoints --
+
+
+@pytest.mark.parametrize("path", sorted(_ALWAYS_SHORT_PATHS))
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_always_short_paths_get_short_ttl(mock_today, path, client):
+    resp = client.get(path, params={"dayObsStart": 20250101, "dayObsEnd": 20250131})
+    assert _cache_header(resp) == f"public, max-age={_TODAY_MAX_AGE}"
+
+
+@pytest.mark.parametrize("path", sorted(_ALWAYS_SHORT_PATHS))
+def test_always_short_paths_without_dayobs(path, client):
+    resp = client.get(path)
+    assert _cache_header(resp) == f"public, max-age={_TODAY_MAX_AGE}"
+
+
+# -- edge cases --
+
+
+def test_invalid_dayobs_no_cache_header(client):
+    resp = client.get("/some-endpoint", params={"dayObs": "not-a-number"})
+    assert _cache_header(resp) is None
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_only_start_param(mock_today, client):
+    resp = client.get("/some-endpoint", params={"dayObsStart": 20250601})
+    assert _cache_header(resp) == f"public, max-age={_HISTORICAL_MAX_AGE}"
+
+
+@patch(
+    "lsst.ts.logging_and_reporting.web_app.middleware.cache_control._today_dayobs",
+    return_value=MOCK_TODAY,
+)
+def test_only_end_param(mock_today, client):
+    resp = client.get("/some-endpoint", params={"dayObsEnd": MOCK_TODAY})
+    assert _cache_header(resp) == f"public, max-age={_TODAY_MAX_AGE}"


### PR DESCRIPTION
Sets Cache-Control: public, max-age=300 for responses including today's dayobs, and max-age=86400 for fully historical responses. TTL is driven by the astronomical dayobs (noon-to-noon UTC). Implemented as a FastAPI middleware.