### PR TITLE
OSW-2773: Implement automatic CI pipeline for image building in merges to develop.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,83 @@
-@Library('JenkinsShared')_
-DevelopPipeline(name: "ts_logging_and_reporting", module_name: "lsst.ts.logging_and_reporting")
+pipeline {
+  options {
+    disableConcurrentBuilds()
+  }
+
+  agent any
+
+  environment {
+    dockerImageName = "rubincr.lsst.org/nightlydigest-backend:"
+    dockerImage = ""
+  }
+
+  stages {
+    stage("Setup and run pre-commit") {
+      agent {
+        docker {
+          alwaysPull true
+          image 'lsstts/develop-env:develop'
+          args "--entrypoint=''"
+        }
+      }
+      steps {
+        script {
+          sh """
+            source /home/saluser/.setup_dev.sh || echo loading env failed. Continuing...
+            generate_pre_commit_conf --skip-pre-commit-install
+            pre-commit run --all
+          """
+        }
+      }
+    }
+
+    stage("Run tests") {
+      agent {
+        docker {
+          alwaysPull true
+          image 'lsstts/develop-env:develop'
+          args "--entrypoint=''"
+        }
+      }
+      steps {
+        script {
+          sh """
+            source /home/saluser/.setup_dev.sh || echo loading env failed. Continuing...
+            pip install -e .
+            pytest -v
+          """
+        }
+      }
+    }
+
+    stage("Build Docker image") {
+      when {
+        anyOf {
+          branch "develop"
+        }
+      }
+      steps {
+        script {
+          image_tag = "develop"
+          dockerImageName = dockerImageName + image_tag
+          echo "dockerImageName: ${dockerImageName}"
+          dockerImage = docker.build(dockerImageName, "-f docker/Dockerfile-deploy .")
+        }
+      }
+    }
+    
+    stage("Push Docker image") {
+      when {
+        anyOf {
+          branch "develop"
+        }
+      }
+      steps {
+        script {
+          docker.withRegistry("https://rubincr.lsst.org/", "nexus3-lsst_jenkins") {
+            dockerImage.push()
+          }
+        }
+      }
+    }
+  }
+}

--- a/doc/news/OSW-2773.misc.rst
+++ b/doc/news/OSW-2773.misc.rst
@@ -1,0 +1,1 @@
+Implement automatic CI pipeline for image building in merges to develop.

--- a/docker/Dockerfile-deploy
+++ b/docker/Dockerfile-deploy
@@ -1,0 +1,44 @@
+ARG cycle=develop
+ARG py_version=3.13
+
+FROM ts-dockerhub.lsst.org/conda_package_builder:latest AS builder
+
+WORKDIR /tmp/build
+COPY . .
+
+RUN source /home/saluser/.setup.sh && \
+    CONDA_BLD_PATH=/tmp/conda-bld conda build --python ${py_version} -c lsstts/label/main --prefix-length 100 --no-test conda/
+
+FROM ts-dockerhub.lsst.org/deploy-env:${cycle}
+
+LABEL maintainer Sebastian Aranda <sebastian.aranda@noirlab.edu>
+
+WORKDIR /home/saluser/develop
+
+COPY --from=builder /tmp/conda-bld /tmp/conda-bld
+COPY . .
+
+USER root
+RUN chown -R saluser:saluser /home/saluser/develop /tmp/conda-bld
+USER saluser
+
+RUN source /home/saluser/.setup_sal_env.sh && \
+	conda index /tmp/conda-bld && \
+    conda install -c file:///tmp/conda-bld ts-logging-and-reporting -y && \
+    conda clean -afy && \
+    rm -rf /tmp/conda-bld
+
+# Workaround required to update astropy and astropy-iers-data
+RUN source /home/saluser/.setup_sal_env.sh && \
+    conda update -y -c conda-forge astropy astropy-iers-data
+
+# Workaround until lsst-resources get conda packaged
+# See: OSW-1382.
+RUN source /home/saluser/.setup_sal_env.sh && \
+    pip install lsst-resources
+
+COPY docker/startup-deploy.sh /home/saluser/.startup.sh
+USER root
+RUN chown saluser:saluser /home/saluser/.startup.sh && \
+    chmod a+x /home/saluser/.startup.sh
+USER saluser

--- a/docker/startup-deploy.sh
+++ b/docker/startup-deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source $HOME/.setup_sal_env.sh
+
+set -eu
+
+# Run the ts_logging_and_reporting FastAPI web server.
+run_logging_and_reporting &
+
+pid="$!"
+
+wait ${pid}


### PR DESCRIPTION
This PR refactors the `Jenkinsfile` to have custom steps for image building when merging PRs to `develop`. A new `Dockerfile-deploy` file was added with the specifications for building images for our deployments.

See https://github.com/lsst-ts/ts_logging_frontend/pull/142.