### PR TITLE
OSW-1382: Add lsst-resources to conda recipe.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -56,3 +56,4 @@ requirements:
         - scikit-learn
         - psycopg2 =2.9
         - astropy-iers-data
+        - lsst-resources

--- a/doc/news/OSW-1382.misc.rst
+++ b/doc/news/OSW-1382.misc.rst
@@ -1,0 +1,1 @@
+Add lsst-resources to conda recipe.

--- a/docker/Dockerfile-deploy
+++ b/docker/Dockerfile-deploy
@@ -34,11 +34,6 @@ RUN source /home/saluser/.setup_sal_env.sh && \
 RUN source /home/saluser/.setup_sal_env.sh && \
     conda update -y -c conda-forge astropy astropy-iers-data
 
-# Workaround until lsst-resources get conda packaged
-# See: OSW-1382.
-RUN source /home/saluser/.setup_sal_env.sh && \
-    pip install lsst-resources
-
 COPY docker/startup-deploy.sh /home/saluser/.startup.sh
 USER root
 RUN chown saluser:saluser /home/saluser/.startup.sh && \


### PR DESCRIPTION
This PR removes the workaround of pip installing `lsst-resources` because it was not conda packaged. Now as the package is available in conda-forge we are adding it to our conda recipe.